### PR TITLE
Add support for multi-document YAML files

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -49,7 +49,7 @@ def pretty_format_yaml(argv=None):
         with open(yaml_file) as f:
             string_content = ''.join(f.readlines())
 
-        separator_pattern = '^--- ?.*\\n'
+        separator_pattern = '^---\\s*\\n'
         original_docs = re.split(separator_pattern, string_content, flags=re.MULTILINE)
         pretty_docs = []
 

--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -15,7 +15,7 @@ from six import StringIO
 from six import text_type
 
 
-def process_single_document(document, yaml):
+def _process_single_document(document, yaml):
     """Pretty format one document containing YAML or primitive (non-YAML) text.
     Call this function for each doc within a multi-document .yaml file.
 

--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -47,14 +47,17 @@ def pretty_format_yaml(argv=None):
             string_content = ''.join(f.readlines())
 
         try:
-            content = yaml.load(string_content)
-
-            if not isinstance(content, (list, dict)):
-                # skip files containing primitive types (unstructured text)
-                continue
-
+            content = list(yaml.load_all(string_content))
             pretty_content = StringIO()
-            yaml.dump(content, pretty_content)
+
+            if len(content) == 1:
+                if not isinstance(content[0], (list, dict)):
+                    # skip files containing primitive types (unstructured text)
+                    continue
+
+                yaml.dump(content[0], pretty_content)
+            else:
+                yaml.dump_all(content, pretty_content)
 
             if string_content != pretty_content.getvalue():
                 print('File {} is not pretty-formatted'.format(yaml_file))

--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -57,6 +57,7 @@ def pretty_format_yaml(argv=None):
 
                 yaml.dump(content[0], pretty_content)
             else:
+                pretty_content.write('---\n')
                 yaml.dump_all(content, pretty_content)
 
             if string_content != pretty_content.getvalue():

--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -16,13 +16,14 @@ from six import text_type
 
 
 def _process_single_document(document, yaml):
-    """Pretty format one document containing YAML or primitive (non-YAML) text.
-    Call this function for each doc within a multi-document .yaml file.
+    """Pretty format one YAML document.
+    
+    This is needed in order to prevent `ruamel.yaml` to interfere with documents that have primitive types on the document root.
+     For more context check https://github.com/macisamuele/language-formatters-pre-commit-hooks/pull/1
 
     Args:
         document (str): Original document content.
         yaml: YAML library instance.
-
     Returns:
         Pretty-formatted content (str).
     """

--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -17,9 +17,9 @@ from six import text_type
 
 def _process_single_document(document, yaml):
     """Pretty format one YAML document.
-    
+
     This is needed in order to prevent `ruamel.yaml` to interfere with documents that have primitive types on the document root.
-     For more context check https://github.com/macisamuele/language-formatters-pre-commit-hooks/pull/1
+    For more context check https://github.com/macisamuele/language-formatters-pre-commit-hooks/pull/1
 
     Args:
         document (str): Original document content.
@@ -76,14 +76,14 @@ def pretty_format_yaml(argv=None):
         #
         # Not using yaml.load_all() because it reformats primitive (non-YAML) content. It removes
         # newline characters.
-        separator_pattern = '^---\\s*\\n'
+        separator_pattern = r'^---\s*\n'
         original_docs = re.split(separator_pattern, string_content, flags=re.MULTILINE)
 
         pretty_docs = []
 
         try:
             for doc in original_docs:
-                content = process_single_document(doc, yaml)
+                content = _process_single_document(doc, yaml)
                 if content is not None:
                     pretty_docs.append(content)
 

--- a/test-data/pretty_format_yaml/multi-doc-not-pretty-formatted.yaml
+++ b/test-data/pretty_format_yaml/multi-doc-not-pretty-formatted.yaml
@@ -1,0 +1,9 @@
+---
+root:
+    test:
+     -  1
+
+---
+second_root:
+   test:
+     - 2

--- a/test-data/pretty_format_yaml/multi-doc-not-pretty-formatted.yaml
+++ b/test-data/pretty_format_yaml/multi-doc-not-pretty-formatted.yaml
@@ -9,6 +9,7 @@ second_root:
           - 2
 ---
 This is a primitive file.
+Another line of text.
 
 Last line of file.
 ---

--- a/test-data/pretty_format_yaml/multi-doc-not-pretty-formatted.yaml
+++ b/test-data/pretty_format_yaml/multi-doc-not-pretty-formatted.yaml
@@ -7,3 +7,12 @@ second_root:
         test:
           - 1
           - 2
+---
+This is a primitive file.
+
+Last line of file.
+---
+third_root:
+  # comment
+  data: abc123
+---

--- a/test-data/pretty_format_yaml/multi-doc-not-pretty-formatted.yaml
+++ b/test-data/pretty_format_yaml/multi-doc-not-pretty-formatted.yaml
@@ -1,9 +1,9 @@
----
-root:
-    test:
-     -  1
-
+  root:
+     test:
+          - hi
+            there
 ---
 second_root:
-   test:
-     - 2
+        test:
+          - 1
+          - 2

--- a/test-data/pretty_format_yaml/multi-doc-pretty-formatted.yaml
+++ b/test-data/pretty_format_yaml/multi-doc-pretty-formatted.yaml
@@ -7,3 +7,11 @@ second_root:
   test:
   - 1
   - 2
+---
+This is a primitive file.
+
+Last line of file.
+---
+third_root:
+  # comment
+  data: abc123

--- a/test-data/pretty_format_yaml/multi-doc-pretty-formatted.yaml
+++ b/test-data/pretty_format_yaml/multi-doc-pretty-formatted.yaml
@@ -9,6 +9,7 @@ second_root:
   - 2
 ---
 This is a primitive file.
+Another line of text.
 
 Last line of file.
 ---

--- a/test-data/pretty_format_yaml/multi-doc-pretty-formatted.yaml
+++ b/test-data/pretty_format_yaml/multi-doc-pretty-formatted.yaml
@@ -1,0 +1,7 @@
+root:
+  test:
+  - 1
+---
+second_root:
+  test:
+  - 2

--- a/test-data/pretty_format_yaml/multi-doc-pretty-formatted.yaml
+++ b/test-data/pretty_format_yaml/multi-doc-pretty-formatted.yaml
@@ -1,7 +1,9 @@
+---
 root:
   test:
-  - 1
+  - hi there
 ---
 second_root:
   test:
+  - 1
   - 2

--- a/tests/pretty_format_yaml_test.py
+++ b/tests/pretty_format_yaml_test.py
@@ -36,23 +36,16 @@ def test_pretty_format_yaml(filename, expected_retval):
     assert pretty_format_yaml([filename]) == expected_retval
 
 
-def test_pretty_format_yaml_autofix(tmpdir):
+@pytest.mark.parametrize(
+    ('no_pretty_file_name'), (
+        ('not-pretty-formatted.yaml'),
+        ('multi-doc-not-pretty-formatted.yaml'),
+    ),
+)
+def test_pretty_format_yaml_autofix(tmpdir, no_pretty_file_name):
     srcfile = tmpdir.join('to_be_fixed.yaml')
     shutil.copyfile(
-        'not-pretty-formatted.yaml',
-        srcfile.strpath,
-    )
-    assert pretty_format_yaml(['--autofix', srcfile.strpath]) == 1
-
-    # file was formatted (shouldn't trigger linter again)
-    ret = pretty_format_yaml([srcfile.strpath])
-    assert ret == 0
-
-
-def test_pretty_format_multidoc_yaml_autofix(tmpdir):
-    srcfile = tmpdir.join('to_be_fixed.yaml')
-    shutil.copyfile(
-        'multi-doc-not-pretty-formatted.yaml',
+        no_pretty_file_name,
         srcfile.strpath,
     )
     assert pretty_format_yaml(['--autofix', srcfile.strpath]) == 1

--- a/tests/pretty_format_yaml_test.py
+++ b/tests/pretty_format_yaml_test.py
@@ -25,6 +25,8 @@ def change_dir():
     ('filename', 'expected_retval'), (
         ('pretty-formatted.yaml', 0),
         ('not-pretty-formatted.yaml', 1),
+        ('multi-doc-pretty-formatted.yaml', 0),
+        ('multi-doc-not-pretty-formatted.yaml', 1),
         ('not-valid-file.yaml', 1),
         ('ansible-vault.yaml', 0),
         ('primitive.yaml', 0),
@@ -38,6 +40,19 @@ def test_pretty_format_yaml_autofix(tmpdir):
     srcfile = tmpdir.join('to_be_fixed.yaml')
     shutil.copyfile(
         'not-pretty-formatted.yaml',
+        srcfile.strpath,
+    )
+    assert pretty_format_yaml(['--autofix', srcfile.strpath]) == 1
+
+    # file was formatted (shouldn't trigger linter again)
+    ret = pretty_format_yaml([srcfile.strpath])
+    assert ret == 0
+
+
+def test_pretty_format_multidoc_yaml_autofix(tmpdir):
+    srcfile = tmpdir.join('to_be_fixed.yaml')
+    shutil.copyfile(
+        'multi-doc-not-pretty-formatted.yaml',
         srcfile.strpath,
     )
     assert pretty_format_yaml(['--autofix', srcfile.strpath]) == 1


### PR DESCRIPTION
I discovered that pretty_format_yaml doesn't work with YAML files containing multiple "documents" in a single stream.  It always fails on these files because it's unable to parse them.  Fortunately, ruamel.yaml provides a simple way to load multiple documents from a file.  It also provides a way to dump them back out.  I took advantage of these functions so it now works on single- and multi-doc files.  New tests are included as well.