### PR TITLE
Replace AOSP with Google Style as default java format

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_java.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_java.py
@@ -35,6 +35,12 @@ def pretty_format_java(argv=None):
         dest='autofix',
         help='Automatically fixes encountered not-pretty-formatted files',
     )
+    parser.add_argument(
+        '--aosp',
+        action='store_true',
+        dest='aosp',
+        help='Formats Java code into AOSP format',
+    )
 
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)
@@ -42,8 +48,9 @@ def pretty_format_java(argv=None):
     google_java_formatter_jar = download_google_java_formatter_jar()
 
     status, output = run_command(
-        'java -jar {} --set-exit-if-changed --aosp {} {}'.format(
+        'java -jar {} --set-exit-if-changed{} {} {}'.format(
             google_java_formatter_jar,
+            ' --aosp' if args.aosp else '',
             '--replace' if args.autofix else '--dry-run',
             ' '.join(set(args.filenames)),
         ),

--- a/test-data/pretty_format_java/valid.java
+++ b/test-data/pretty_format_java/valid.java
@@ -1,7 +1,7 @@
 public class HelloWorld {
 
-    public static void main(String[] args) {
-        // Prints "Hello, World" to the terminal window.
-        System.out.println("Hello, World");
-    }
+  public static void main(String[] args) {
+    // Prints "Hello, World" to the terminal window.
+    System.out.println("Hello, World");
+  }
 }


### PR DESCRIPTION
Addresses Issue: https://github.com/macisamuele/language-formatters-pre-commit-hooks/issues/7

This change changes the default formatting to use Google Java Format instead of AOSP. A flag for AOSP is added for users who want that format style.