### PR TITLE
Do not setup Rust on publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,11 +17,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.pyversion }}
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
     - name: Install Python dependencies
       run: pip install wheel
     - name: Create a Wheel file and source distribution


### PR DESCRIPTION
Rust is not needed when publishing, so we should be good to go 👍 