### PR TITLE
Add --preserve-quotes argument in YAML formatter

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -54,6 +54,12 @@ def pretty_format_yaml(argv=None):
             ' for indentation level e.g. 4 or "\t" (Default: 2)'
         ),
     )
+    parser.add_argument(
+        '--preserve-quotes',
+        action='store_true',
+        dest='preserve_quotes',
+        help='Keep existing string quoting',
+    )
 
     parser.add_argument('filenames', nargs='*', help='Filenames to fix')
     args = parser.parse_args(argv)
@@ -62,6 +68,7 @@ def pretty_format_yaml(argv=None):
 
     yaml = YAML()
     yaml.indent = args.indent
+    yaml.preserve_quotes = args.preserve_quotes
     # Prevent ruamel.yaml to wrap yaml lines
     yaml.width = maxsize
 

--- a/test-data/pretty_format_yaml/preserve-quotes-pretty-formatted.yaml
+++ b/test-data/pretty_format_yaml/preserve-quotes-pretty-formatted.yaml
@@ -1,0 +1,4 @@
+root:
+  test: "test"
+  foo: 'bar'
+

--- a/tests/pretty_format_yaml_test.py
+++ b/tests/pretty_format_yaml_test.py
@@ -56,3 +56,9 @@ def test_pretty_format_yaml_autofix(tmpdir, no_pretty_file_name):
     # file was formatted (shouldn't trigger linter again)
     ret = pretty_format_yaml([srcfile.strpath])
     assert ret == 0
+
+
+def test_pretty_format_yaml_preserve_quotes():
+    filename = 'preserve-quotes-pretty-formatted.yaml'
+    assert pretty_format_yaml([filename]) == 1
+    assert pretty_format_yaml(['--preserve-quotes', filename]) == 0


### PR DESCRIPTION
`--preserve-quotes` argument in yaml formatter will keep quotes around string value definition.
eg. :
```
root:
  test: "test"
```
without this option, would be autofix in :
```
root:
  test: test
```

Signed-off-by: Vincent Bisserie <vincent.bisserie@renault.com>