### PR TITLE
Run java serially

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -22,6 +22,7 @@
   language: python
   types: [java]
   files: ^.+\.java$
+  require_serial: true
   minimum_pre_commit_version: 0.15.0
 - id: pretty-format-kotlin
   name: KTLint


### PR DESCRIPTION
When I tried to use it, it produced a lot of errors while downloading the google formatter. From what
I can gather, the following happens when a lot of files are formatted:
- pre-commit calls `pretty-format-java` in parallel with a bunch of files in each call
- each `pretty-format-java` tries to download the google formatter
- all but one fail

Most probably the other formatters should also have `require_serial`...