### PR TITLE
Limit race conditions in download_url for parallel downloads of same resource

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - maci-*
   pull_request:
     branches:
     - '*'

--- a/language_formatters_pre_commit_hooks/utils.py
+++ b/language_formatters_pre_commit_hooks/utils.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 
 import requests
 from six.moves.urllib.parse import urlparse
@@ -57,12 +58,12 @@ def download_url(url, file_name=None):
         os.mkdir(base_directory)
 
     r = requests.get(url, stream=True)
-    tmp_file = '{}_tmp'.format(final_file)
-    with open(tmp_file, mode='wb') as f:
-        # Copy on a temporary file in case of issues while downloading the file
-        shutil.copyfileobj(r.raw, f)
+    with tempfile.NamedTemporaryFile(delete=False) as tmp_file:  # Not delete because we're renaming it
+        shutil.copyfileobj(r.raw, tmp_file)
+        tmp_file.flush()
+        os.fsync(tmp_file.fileno())
+        os.rename(tmp_file.name, final_file)
 
-    os.rename(tmp_file, final_file)
     return final_file
 
 

--- a/language_formatters_pre_commit_hooks/utils.py
+++ b/language_formatters_pre_commit_hooks/utils.py
@@ -37,13 +37,24 @@ def _base_directory():
 
 
 def download_url(url, file_name=None):
+    base_directory = _base_directory()
+
     final_file = os.path.join(
-        _base_directory(),
+        base_directory,
         file_name or os.path.basename(urlparse(url).path),
     )
 
     if os.path.exists(final_file):
         return final_file
+
+    if not os.path.exists(base_directory):  # pragma: no cover
+        # If the base directory is not present we should create it.
+        # This is needed to allow the tool to run if invoked via
+        # command line, but it should never be possible if invoked
+        # via `pre-commit` as it would ensure that the directories
+        # are present
+        print('Unexisting base directory ({base_directory}). Creating it'.format(base_directory=base_directory), file=sys.stderr)
+        os.mkdir(base_directory)
 
     r = requests.get(url, stream=True)
     tmp_file = '{}_tmp'.format(final_file)


### PR DESCRIPTION
This was first noticed in #23.
The fix idea is to use a really temporary file instead of a tmp suffixed file for handling conditions of multiple-parallel downloads.

It's out of the scope of the change the addition of logic that would limit the parallel download of the resource.
This is justified (at least at the moment) by the fact that the resource download happens only around the time of the bump of the version and for the very first pre-commit run, so it should be acceptable.

The PR also ensures that `base_directory` exists before writing file on it.
This is generally not an issue while running through pre-commit, but it might be relevant if running the pretty formatters directly from the virtual-environment (ie. `./venv/bin/pretty-format-java ...`)