### PR TITLE
Update `files` to empty string for backward compatibility

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   entry: pretty-format-golang
   language: python
   types: [go]
-  files: ^.+\.go$
+  files: ''
   minimum_pre_commit_version: 0.15.0
 - id: pretty-format-ini
   name: Pretty format INI
@@ -13,7 +13,7 @@
   language: python
   types: [ini]
     # for backward compatibility
-  files: ^.*\.ini$
+  files: ''
   minimum_pre_commit_version: 0.15.0
 - id: pretty-format-java
   name: Google Java Formatter
@@ -21,7 +21,7 @@
   entry: pretty-format-java
   language: python
   types: [java]
-  files: ^.+\.java$
+  files: ''
   require_serial: true
   minimum_pre_commit_version: 0.15.0
 - id: pretty-format-kotlin
@@ -30,7 +30,7 @@
   entry: pretty-format-kotlin
   language: python
   types: [kotlin]
-  files: ^.+\.kt$
+  files: ''
   minimum_pre_commit_version: 0.15.0
   require_serial: true  # this is needed because the tool does use git commands internally to evanuate diffs
 - id: pretty-format-rust
@@ -39,7 +39,7 @@
   entry: pretty-format-rust
   language: python
   types: [rust]
-  files: ^.+\.rs$
+  files: ''
   minimum_pre_commit_version: 0.15.0
 - id: pretty-format-toml
   name: Pretty format TOML
@@ -48,7 +48,7 @@
   language: python
   types: [toml]
     # for backward compatibility
-  files: ^.*\.toml$
+  files: ''
   minimum_pre_commit_version: 0.15.0
 - id: pretty-format-yaml
   name: Pretty format YAML
@@ -57,5 +57,5 @@
   language: python
   types: [yaml]
     # for backward compatibility
-  files: ^.*\.(yaml|yml)$
+  files: ''
   minimum_pre_commit_version: 0.15.0

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,34 +4,29 @@
   entry: pretty-format-golang
   language: python
   types: [go]
-  files: ''
-  minimum_pre_commit_version: 0.15.0
+  minimum_pre_commit_version: '1'
 - id: pretty-format-ini
   name: Pretty format INI
   description: This hook sets a standard for formatting INI  files.
   entry: pretty-format-ini
   language: python
   types: [ini]
-    # for backward compatibility
-  files: ''
-  minimum_pre_commit_version: 0.15.0
+  minimum_pre_commit_version: '1'
 - id: pretty-format-java
   name: Google Java Formatter
   description: Runs Google Java Formatter over Java source files
   entry: pretty-format-java
   language: python
   types: [java]
-  files: ''
   require_serial: true
-  minimum_pre_commit_version: 0.15.0
+  minimum_pre_commit_version: '1'
 - id: pretty-format-kotlin
   name: KTLint
   description: Runs KTLint over Kotlin source files
   entry: pretty-format-kotlin
   language: python
   types: [kotlin]
-  files: ''
-  minimum_pre_commit_version: 0.15.0
+  minimum_pre_commit_version: '1'
   require_serial: true  # this is needed because the tool does use git commands internally to evanuate diffs
 - id: pretty-format-rust
   name: cargo-fmt
@@ -39,23 +34,18 @@
   entry: pretty-format-rust
   language: python
   types: [rust]
-  files: ''
-  minimum_pre_commit_version: 0.15.0
+  minimum_pre_commit_version: '1'
 - id: pretty-format-toml
   name: Pretty format TOML
   description: This hook sets a standard for formatting TOML files.
   entry: pretty-format-toml
   language: python
   types: [toml]
-    # for backward compatibility
-  files: ''
-  minimum_pre_commit_version: 0.15.0
+  minimum_pre_commit_version: '1'
 - id: pretty-format-yaml
   name: Pretty format YAML
   description: This hook sets a standard for formatting YAML files.
   entry: pretty-format-yaml
   language: python
   types: [yaml]
-    # for backward compatibility
-  files: ''
-  minimum_pre_commit_version: 0.15.0
+  minimum_pre_commit_version: '1'


### PR DESCRIPTION
According to https://github.com/pre-commit/pre-commit/pull/551#issuecomment-312535540 it's preferable to use empty `files` as they're computed in AND together with `types`.

Fixes #25 