### PR TITLE
Pretty format kotlin independent from git

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -18,6 +18,8 @@
   entry: pretty-format-java
   language: python
   types: [java]
+  # this is needed because the hook downloads google-java-formatter and
+  # we don't have yet a nice way of ensuring a single download over multiple runs
   require_serial: true
   minimum_pre_commit_version: '1'
 - id: pretty-format-kotlin
@@ -27,7 +29,9 @@
   language: python
   types: [kotlin]
   minimum_pre_commit_version: '1'
-  require_serial: true  # this is needed because the tool does use git commands internally to evanuate diffs
+  # this is needed because the hook downloads ktlint and we don't have yet a
+  # nice way of ensuring a single download over multiple runs
+  require_serial: true
 - id: pretty-format-rust
   name: cargo-fmt
   description: Runs cargo fmt over Rust source files

--- a/language_formatters_pre_commit_hooks/utils.py
+++ b/language_formatters_pre_commit_hooks/utils.py
@@ -67,17 +67,6 @@ def download_url(url, file_name=None):
     return final_file
 
 
-def get_modified_files_in_repo():
-    _, command_output = run_command(
-        'git diff-index --name-status --binary --exit-code --no-ext-diff $(git write-tree) --',
-    )
-    return {
-        line.split()[-1]
-        for line in command_output.splitlines()
-        if line
-    }
-
-
 def remove_trailing_whitespaces_and_set_new_line_ending(string):
     return '{content}\n'.format(
         content='\n'.join(

--- a/language_formatters_pre_commit_hooks/utils.py
+++ b/language_formatters_pre_commit_hooks/utils.py
@@ -57,7 +57,9 @@ def download_url(url, file_name=None):
         print('Unexisting base directory ({base_directory}). Creating it'.format(base_directory=base_directory), file=sys.stderr)
         os.mkdir(base_directory)
 
+    print("Downloading {url}".format(url=url), file=sys.stderr)
     r = requests.get(url, stream=True)
+    r.raise_for_status()
     with tempfile.NamedTemporaryFile(delete=False) as tmp_file:  # Not delete because we're renaming it
         shutil.copyfileobj(r.raw, tmp_file)
         tmp_file.flush()

--- a/tests/pretty_format_kotlin_test.py
+++ b/tests/pretty_format_kotlin_test.py
@@ -8,7 +8,6 @@ import shutil
 import pytest
 
 from language_formatters_pre_commit_hooks.pretty_format_kotlin import pretty_format_kotlin
-from language_formatters_pre_commit_hooks.utils import run_command
 from tests.conftest import change_dir_context
 from tests.conftest import undecorate_function
 
@@ -42,15 +41,9 @@ def test_pretty_format_kotlin_autofix(tmpdir, undecorate_method):
         'invalid.kt',
         srcfile.strpath,
     )
-    with change_dir_context(tmpdir.strpath):
-        # KTLint does not provide information if files have been formatted
-        # so the only way is to check if there are non stashed files in the repo
-        run_command('git init && git add {}'.format(srcfile.strpath))
-
+    with change_dir_context(tmpdir.dirname):
         assert undecorate_method(['--autofix', srcfile.strpath]) == 1
 
-        # Stage the file in the repository
-        run_command('git add {}'.format(srcfile.strpath))
-
         # file was formatted (shouldn't trigger linter again)
-        assert undecorate_method([srcfile.strpath]) == 0
+        ret = undecorate_method([srcfile.strpath])
+        assert ret == 0


### PR DESCRIPTION
The goal of this PR is to remove the direct `git` dependency that is present into `pretty-format-kotlin`.

The git dependency is needed because while running `ktlint` in autofix mode (so with `--format` argument), the tool does not provide any information around the modified files or un-fixable files.

To workaround this limitation the implementation was "manually" comparing the diff pre and post ktlint execution.
This approach made the hook incompatible with parallel run (as we would check the diff of the whole repo).

This PR tries to use a different approach:
* we run ktlint in check mode such that we can have information about what files are not consistent with the kotlin formatting
* run ktlint with `--format` flag, if autofix is enabled, only on these files

The execution time of the hook will be:
 * the same if no files needs to be fixed
 * a bit longer if files needs to be formatted
    NOTE: The time penalty should be comparable with the time saving of not interacting with git, especially for bigger projects. Moreover it would, not in this PR, allow us to run the hook in parallel which should reduce the overall perceived execution time.

---

An additional change introduced by this PR is the capability of defining the Google Java Formatter or KTlint version to be used via pre-commit hooks arguments. In this way we can test new versions of the external tools before bumping this library and provides freedom to the user of this library to use a different version if they like

Example of usage
```yaml
- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
  rev: ...
  hooks:
  - id: pretty-format-java
    args:
    - --google-java-formatter-version
    - '1.5'
  - id: pretty-format-kotlin
    args:
    - --ktlint-version
    - 0.35.0
```