### PR TITLE
Bump pre-commit hooks and use black formatter

### DIFF
--- a/.black.toml
+++ b/.black.toml
@@ -1,0 +1,4 @@
+[tool.black]
+include = '\.pyi?$'
+line-length = 141
+target-version = ['py27']

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,7 +63,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install Python dependencies
       run: pip install tox
     - name: Run Tox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,14 @@
+default_language_version:
+  python: python3.7
+
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v1.3.0
+- repo: https://github.com/pre-commit/pre-commit
+  rev: v2.7.1
   hooks:
-  - id: autopep8-wrapper
+  - id: validate_manifest
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.2.0
+  hooks:
   - id: check-added-large-files
   - id: check-docstring-first
   - id: check-json
@@ -12,7 +18,6 @@ repos:
   - id: debug-statements
   - id: end-of-file-fixer
     exclude: ^test-data/.*$
-  - id: flake8
   - id: name-tests-test
   - id: pretty-format-json
     args: [--autofix, --indent, '4']
@@ -21,12 +26,8 @@ repos:
   - id: trailing-whitespace
     exclude: ^test-data/.*$
   - id: fix-encoding-pragma
-- repo: https://github.com/pre-commit/pre-commit
-  rev: v1.10.3
-  hooks:
-  - id: validate_manifest
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v1.1.0
+  rev: v2.3.5
   hooks:
   - id: reorder-python-imports
     args:
@@ -36,18 +37,19 @@ repos:
     - from __future__ import print_function
     - --add-import
     - from __future__ import unicode_literals
-- repo: https://github.com/asottile/pyupgrade
-  rev: v1.4.0
-  hooks:
-  - id: pyupgrade
-- repo: https://github.com/asottile/add-trailing-comma
-  rev: v0.6.4
-  hooks:
-  - id: add-trailing-comma
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v1.0.1
+  rev: v1.5.0
   hooks:
   - id: pretty-format-yaml
     exclude: ^test-data/.*$
     args:
     - --autofix
+- repo: https://github.com/ambv/black
+  rev: 20.8b1
+  hooks:
+  - id: black
+    args: [--config, .black.toml]
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.8.3
+  hooks:
+  - id: flake8

--- a/language_formatters_pre_commit_hooks/__init__.py
+++ b/language_formatters_pre_commit_hooks/__init__.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import pkg_resources
 
 
-__version__ = pkg_resources.get_distribution('language_formatters_pre_commit_hooks').version
+__version__ = pkg_resources.get_distribution("language_formatters_pre_commit_hooks").version
 
 
 def _get_default_version(tool_name):  # pragma: no cover
@@ -15,9 +15,12 @@ def _get_default_version(tool_name):  # pragma: no cover
     The method is intended to be used only from language_formatters_pre_commit_hooks modules
     """
     try:
-        with open(pkg_resources.resource_filename(
-            'language_formatters_pre_commit_hooks', "{tool_name}.version".format(tool_name=tool_name),
-        )) as f:
+        with open(
+            pkg_resources.resource_filename(
+                "language_formatters_pre_commit_hooks",
+                "{tool_name}.version".format(tool_name=tool_name),
+            )
+        ) as f:
             return f.readline().split()[0]
     except:  # noqa: E722 (allow usage of bare 'except')
         raise RuntimeError("No default version found for {tool_name}".format(tool_name=tool_name))

--- a/language_formatters_pre_commit_hooks/pre_conditions.py
+++ b/language_formatters_pre_commit_hooks/pre_conditions.py
@@ -9,9 +9,11 @@ from decorator import decorator
 
 from language_formatters_pre_commit_hooks.utils import run_command
 
-_DEFAULT_MESSAGE_TEMPLATE = '{required_tool} is required to run this pre-commit hook. ' \
-                            'Make sure that you have it installed and available on your path.\n' \
-                            'Download/Install URL: {install_url}'
+_DEFAULT_MESSAGE_TEMPLATE = (
+    "{required_tool} is required to run this pre-commit hook. "
+    "Make sure that you have it installed and available on your path.\n"
+    "Download/Install URL: {install_url}"
+)
 
 
 def _assert_command_succeed(command, assertion_error_message):
@@ -22,10 +24,10 @@ def _assert_command_succeed(command, assertion_error_message):
 @decorator
 def java_required(f, *args, **kwargs):
     _assert_command_succeed(
-        command='java -version',
+        command="java -version",
         assertion_error_message=_DEFAULT_MESSAGE_TEMPLATE.format(
-            required_tool='JRE',
-            install_url='https://www.java.com/en/download/',
+            required_tool="JRE",
+            install_url="https://www.java.com/en/download/",
         ),
     )
     return f(*args, **kwargs)
@@ -34,10 +36,10 @@ def java_required(f, *args, **kwargs):
 @decorator
 def golang_required(f, *args, **kwargs):
     _assert_command_succeed(
-        command='go version',
+        command="go version",
         assertion_error_message=_DEFAULT_MESSAGE_TEMPLATE.format(
-            required_tool='golang/gofmt',
-            install_url='https://golang.org/doc/install#download',
+            required_tool="golang/gofmt",
+            install_url="https://golang.org/doc/install#download",
         ),
     )
 
@@ -46,12 +48,12 @@ def golang_required(f, *args, **kwargs):
 
 @decorator
 def rust_required(f, *args, **kwargs):
-    rust_toolchain_version = getenv('RUST_TOOLCHAIN', 'stable')
+    rust_toolchain_version = getenv("RUST_TOOLCHAIN", "stable")
     _assert_command_succeed(
-        command='cargo +{} fmt  -- --version'.format(rust_toolchain_version),
+        command="cargo +{} fmt  -- --version".format(rust_toolchain_version),
         assertion_error_message=_DEFAULT_MESSAGE_TEMPLATE.format(
-            required_tool='rustfmt',
-            install_url='https://github.com/rust-lang-nursery/rustfmt#quick-start',
+            required_tool="rustfmt",
+            install_url="https://github.com/rust-lang-nursery/rustfmt#quick-start",
         ),
     )
 

--- a/language_formatters_pre_commit_hooks/pretty_format_golang.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_golang.py
@@ -15,17 +15,17 @@ def _get_eol_attribute():
     Retrieve eol attribute defined for golang files
     The method will return None in case of any error interacting with git
     """
-    status_code, output = run_command('git check-attr -z eol -- filename.go')
+    status_code, output = run_command("git check-attr -z eol -- filename.go")
     if status_code != 0:
         return None
 
     try:
         # Expected output: "filename.go\0eol\0lf\0"
-        _, _, eol, _ = output.split('\0')
+        _, _, eol, _ = output.split("\0")
         return eol
     except:  # noqa: E722 (allow usage of bare 'except')
         print(
-            '`git check-attr` output is not consistent to `<filename>\0<key>\0<value>\0` format: {output}'.format(
+            "`git check-attr` output is not consistent to `<filename>\0<key>\0<value>\0` format: {output}".format(
                 output=output,
             ),
             file=sys.stderr,
@@ -37,19 +37,19 @@ def _get_eol_attribute():
 def pretty_format_golang(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--autofix',
-        action='store_true',
-        dest='autofix',
-        help='Automatically fixes encountered not-pretty-formatted files',
+        "--autofix",
+        action="store_true",
+        dest="autofix",
+        help="Automatically fixes encountered not-pretty-formatted files",
     )
 
-    parser.add_argument('filenames', nargs='*', help='Filenames to fix')
+    parser.add_argument("filenames", nargs="*", help="Filenames to fix")
     args = parser.parse_args(argv)
 
     status, output = run_command(
-        'gofmt{} -l {}'.format(
-            ' -w' if args.autofix else '',
-            ' '.join(set(args.filenames)),
+        "gofmt{} -l {}".format(
+            " -w" if args.autofix else "",
+            " ".join(set(args.filenames)),
         ),
     )
 
@@ -61,23 +61,23 @@ def pretty_format_golang(argv=None):
     if output:
         status = 1
         print(
-            '{}: {}'.format(
-                'The following files have been fixed by gofmt' if args.autofix else 'The following files are not properly formatted',
-                ', '.join(output.splitlines()),
+            "{}: {}".format(
+                "The following files have been fixed by gofmt" if args.autofix else "The following files are not properly formatted",
+                ", ".join(output.splitlines()),
             ),
         )
-        if sys.platform == 'win32':  # pragma: no cover
+        if sys.platform == "win32":  # pragma: no cover
             eol_attribute = _get_eol_attribute()
-            if eol_attribute and eol_attribute != 'lf':
+            if eol_attribute and eol_attribute != "lf":
                 print(
-                    'Hint: gofmt uses LF (aka `\\n`) as new line, but on Windows the default new line is CRLF (aka `\\r\\n`). '
-                    'You might want to ensure that go files are forced to use LF via `.gitattributes`. '
-                    'Example: https://github.com/macisamuele/language-formatters-pre-commit-hooks/commit/53f27fda02ead5b1b9b6a9bbd9c36bb66d229887',  # noqa: E501
+                    "Hint: gofmt uses LF (aka `\\n`) as new line, but on Windows the default new line is CRLF (aka `\\r\\n`). "
+                    "You might want to ensure that go files are forced to use LF via `.gitattributes`. "
+                    "Example: https://github.com/macisamuele/language-formatters-pre-commit-hooks/commit/53f27fda02ead5b1b9b6a9bbd9c36bb66d229887",  # noqa: E501
                     file=sys.stderr,
                 )
 
     return status
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pretty_format_golang())

--- a/language_formatters_pre_commit_hooks/pretty_format_ini.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_ini.py
@@ -19,20 +19,20 @@ from language_formatters_pre_commit_hooks.utils import remove_trailing_whitespac
 def pretty_format_ini(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--autofix',
-        action='store_true',
-        dest='autofix',
-        help='Automatically fixes encountered not-pretty-formatted files',
+        "--autofix",
+        action="store_true",
+        dest="autofix",
+        help="Automatically fixes encountered not-pretty-formatted files",
     )
 
-    parser.add_argument('filenames', nargs='*', help='Filenames to fix')
+    parser.add_argument("filenames", nargs="*", help="Filenames to fix")
     args = parser.parse_args(argv)
 
     status = 0
 
     for ini_file in set(args.filenames):
         with open(ini_file) as f:
-            string_content = ''.join(f.readlines())
+            string_content = "".join(f.readlines())
 
         config_parser = ConfigParser()
         try:
@@ -49,20 +49,20 @@ def pretty_format_ini(argv=None):
             )
 
             if string_content != pretty_content_str:
-                print('File {} is not pretty-formatted'.format(ini_file))
+                print("File {} is not pretty-formatted".format(ini_file))
 
                 if args.autofix:
-                    print('Fixing file {}'.format(ini_file))
-                    with io.open(ini_file, 'w', encoding='UTF-8') as f:
+                    print("Fixing file {}".format(ini_file))
+                    with io.open(ini_file, "w", encoding="UTF-8") as f:
                         f.write(text_type(pretty_content_str))
 
                 status = 1
         except Error:
-            print('Input File {} is not a valid INI file'.format(ini_file))
+            print("Input File {} is not a valid INI file".format(ini_file))
             return 1
 
     return status
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pretty_format_ini())

--- a/language_formatters_pre_commit_hooks/pretty_format_java.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_java.py
@@ -15,20 +15,22 @@ from language_formatters_pre_commit_hooks.utils import run_command
 def __download_google_java_formatter_jar(version):  # pragma: no cover
     def get_url(_version):
         # Links extracted from https://github.com/google/google-java-format/
-        return \
-            'https://github.com/google/google-java-format/releases/download/' \
-            'google-java-format-{version}/google-java-format-{version}-all-deps.jar'.format(
+        return (
+            "https://github.com/google/google-java-format/releases/download/"
+            "google-java-format-{version}/google-java-format-{version}-all-deps.jar".format(
                 version=_version,
             )
+        )
 
     url_to_download = get_url(version)
     try:
-        return download_url(get_url(version), 'ktlint{version}.jar'.format(version=version))
+        return download_url(get_url(version), "ktlint{version}.jar".format(version=version))
     except:  # noqa: E722 (allow usage of bare 'except')
         raise RuntimeError(
-            'Failed to download {url}. Probably the requested version, {version}, is '
-            'not valid or you have some network issue.'.format(
-                url=url_to_download, version=version,
+            "Failed to download {url}. Probably the requested version, {version}, is "
+            "not valid or you have some network issue.".format(
+                url=url_to_download,
+                version=version,
             ),
         )
 
@@ -37,25 +39,25 @@ def __download_google_java_formatter_jar(version):  # pragma: no cover
 def pretty_format_java(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--autofix',
-        action='store_true',
-        dest='autofix',
-        help='Automatically fixes encountered not-pretty-formatted files',
+        "--autofix",
+        action="store_true",
+        dest="autofix",
+        help="Automatically fixes encountered not-pretty-formatted files",
     )
     parser.add_argument(
-        '--google-java-formatter-version',
-        dest='google_java_formatter_version',
-        default=_get_default_version('google_java_formatter'),
-        help='Google Java Formatter version to use (default %(default)s)',
+        "--google-java-formatter-version",
+        dest="google_java_formatter_version",
+        default=_get_default_version("google_java_formatter"),
+        help="Google Java Formatter version to use (default %(default)s)",
     )
     parser.add_argument(
-        '--aosp',
-        action='store_true',
-        dest='aosp',
-        help='Formats Java code into AOSP format',
+        "--aosp",
+        action="store_true",
+        dest="aosp",
+        help="Formats Java code into AOSP format",
     )
 
-    parser.add_argument('filenames', nargs='*', help='Filenames to fix')
+    parser.add_argument("filenames", nargs="*", help="Filenames to fix")
     args = parser.parse_args(argv)
 
     google_java_formatter_jar = __download_google_java_formatter_jar(
@@ -63,24 +65,26 @@ def pretty_format_java(argv=None):
     )
 
     status, output = run_command(
-        'java -jar {} --set-exit-if-changed{} {} {}'.format(
+        "java -jar {} --set-exit-if-changed{} {} {}".format(
             google_java_formatter_jar,
-            ' --aosp' if args.aosp else '',
-            '--replace' if args.autofix else '--dry-run',
-            ' '.join(set(args.filenames)),
+            " --aosp" if args.aosp else "",
+            "--replace" if args.autofix else "--dry-run",
+            " ".join(set(args.filenames)),
         ),
     )
 
     if output:
         print(
-            '{}: {}'.format(
-                'The following files have been fixed by google-java-formatter' if args.autofix else 'The following files are not properly formatted',  # noqa
-                ', '.join(output.splitlines()),
+            "{}: {}".format(
+                "The following files have been fixed by google-java-formatter"
+                if args.autofix
+                else "The following files are not properly formatted",  # noqa
+                ", ".join(output.splitlines()),
             ),
         )
 
     return 0 if status == 0 else 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pretty_format_java())

--- a/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
@@ -15,19 +15,19 @@ from language_formatters_pre_commit_hooks.utils import run_command
 def __download_kotlin_formatter_jar(version):  # pragma: no cover
     def get_url(_version):
         # Links extracted from https://github.com/pinterest/ktlint/
-        return \
-            'https://github.com/pinterest/ktlint/releases/download/{version}/ktlint'.format(
-                version=_version,
-            )
+        return "https://github.com/pinterest/ktlint/releases/download/{version}/ktlint".format(
+            version=_version,
+        )
 
     url_to_download = get_url(version)
     try:
-        return download_url(get_url(version), 'ktlint{version}.jar'.format(version=version))
+        return download_url(get_url(version), "ktlint{version}.jar".format(version=version))
     except:  # noqa: E722 (allow usage of bare 'except')
         raise RuntimeError(
-            'Failed to download {url}. Probably the requested version, {version}, is '
-            'not valid or you have some network issue.'.format(
-                url=url_to_download, version=version,
+            "Failed to download {url}. Probably the requested version, {version}, is "
+            "not valid or you have some network issue.".format(
+                url=url_to_download,
+                version=version,
             ),
         )
 
@@ -36,19 +36,19 @@ def __download_kotlin_formatter_jar(version):  # pragma: no cover
 def pretty_format_kotlin(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--autofix',
-        action='store_true',
-        dest='autofix',
-        help='Automatically fixes encountered not-pretty-formatted files',
+        "--autofix",
+        action="store_true",
+        dest="autofix",
+        help="Automatically fixes encountered not-pretty-formatted files",
     )
     parser.add_argument(
-        '--ktlint-version',
-        dest='ktlint_version',
-        default=_get_default_version('ktlint'),
-        help='KTLint version to use (default %(default)s)',
+        "--ktlint-version",
+        dest="ktlint_version",
+        default=_get_default_version("ktlint"),
+        help="KTLint version to use (default %(default)s)",
     )
 
-    parser.add_argument('filenames', nargs='*', help='Filenames to fix')
+    parser.add_argument("filenames", nargs="*", help="Filenames to fix")
     args = parser.parse_args(argv)
 
     ktlint_jar = __download_kotlin_formatter_jar(
@@ -60,25 +60,22 @@ def pretty_format_kotlin(argv=None):
     # which provides the expected exit status and we run it again in format
     # mode if autofix flag is enabled
     check_status, check_output = run_command(
-        'java -jar {} --verbose --relative -- {}'.format(
+        "java -jar {} --verbose --relative -- {}".format(
             ktlint_jar,
-            ' '.join(set(args.filenames)),
+            " ".join(set(args.filenames)),
         ),
     )
 
     not_pretty_formatted_files = set()
     if check_status != 0:
-        not_pretty_formatted_files.update(
-            line.split(':', 1)[0]
-            for line in check_output.splitlines()
-        )
+        not_pretty_formatted_files.update(line.split(":", 1)[0] for line in check_output.splitlines())
 
         if args.autofix:
-            print('Running ktlint format on {}'.format(not_pretty_formatted_files))
+            print("Running ktlint format on {}".format(not_pretty_formatted_files))
             run_command(
-                'java -jar {} --verbose --relative --format -- {}'.format(
+                "java -jar {} --verbose --relative --format -- {}".format(
                     ktlint_jar,
-                    ' '.join(not_pretty_formatted_files),
+                    " ".join(not_pretty_formatted_files),
                 ),
             )
 
@@ -86,14 +83,14 @@ def pretty_format_kotlin(argv=None):
     if not_pretty_formatted_files:
         status = 1
         print(
-            '{}: {}'.format(
-                'The following files have been fixed by ktlint' if args.autofix else 'The following files are not properly formatted',
-                ', '.join(sorted(not_pretty_formatted_files)),
+            "{}: {}".format(
+                "The following files have been fixed by ktlint" if args.autofix else "The following files are not properly formatted",
+                ", ".join(sorted(not_pretty_formatted_files)),
             ),
         )
 
     return status
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pretty_format_kotlin())

--- a/language_formatters_pre_commit_hooks/pretty_format_rust.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_rust.py
@@ -15,45 +15,41 @@ from language_formatters_pre_commit_hooks.utils import run_command
 def pretty_format_rust(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--autofix',
-        action='store_true',
-        dest='autofix',
-        help='Automatically fixes encountered not-pretty-formatted files',
+        "--autofix",
+        action="store_true",
+        dest="autofix",
+        help="Automatically fixes encountered not-pretty-formatted files",
     )
 
-    parser.add_argument('filenames', nargs='*', help='Filenames to fix')
+    parser.add_argument("filenames", nargs="*", help="Filenames to fix")
     args = parser.parse_args(argv)
 
-    rust_toolchain_version = getenv('RUST_TOOLCHAIN', 'stable')
+    rust_toolchain_version = getenv("RUST_TOOLCHAIN", "stable")
     # Check
     status_code, output = run_command(
-        'cargo +{} fmt -- --check {}'.format(
+        "cargo +{} fmt -- --check {}".format(
             rust_toolchain_version,
-            ' '.join(set(args.filenames)),
+            " ".join(set(args.filenames)),
         ),
     )
-    not_well_formatted_files = sorted(
-        line.split()[2]
-        for line in output.splitlines()
-        if line.startswith('Diff in ')
-    )
+    not_well_formatted_files = sorted(line.split()[2] for line in output.splitlines() if line.startswith("Diff in "))
     if not_well_formatted_files:
         print(
-            '{}: {}'.format(
-                'The following files have been fixed by cargo format' if args.autofix else 'The following files are not properly formatted',
-                ', '.join(not_well_formatted_files),
+            "{}: {}".format(
+                "The following files have been fixed by cargo format" if args.autofix else "The following files are not properly formatted",
+                ", ".join(not_well_formatted_files),
             ),
         )
         if args.autofix:
             run_command(
-                'cargo +{} fmt -- {}'.format(
+                "cargo +{} fmt -- {}".format(
                     rust_toolchain_version,
-                    ' '.join(not_well_formatted_files),
+                    " ".join(not_well_formatted_files),
                 ),
             )
 
     return 1 if status_code != 0 or not_well_formatted_files else 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pretty_format_rust())

--- a/language_formatters_pre_commit_hooks/pretty_format_toml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_toml.py
@@ -17,20 +17,20 @@ from language_formatters_pre_commit_hooks.utils import remove_trailing_whitespac
 def pretty_format_toml(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--autofix',
-        action='store_true',
-        dest='autofix',
-        help='Automatically fixes encountered not-pretty-formatted files',
+        "--autofix",
+        action="store_true",
+        dest="autofix",
+        help="Automatically fixes encountered not-pretty-formatted files",
     )
 
-    parser.add_argument('filenames', nargs='*', help='Filenames to fix')
+    parser.add_argument("filenames", nargs="*", help="Filenames to fix")
     args = parser.parse_args(argv)
 
     status = 0
 
     for toml_file in set(args.filenames):
         with open(toml_file) as f:
-            string_content = ''.join(f.readlines())
+            string_content = "".join(f.readlines())
 
         try:
             prettified_content = remove_trailing_whitespaces_and_set_new_line_ending(
@@ -38,20 +38,20 @@ def pretty_format_toml(argv=None):
             )
 
             if string_content != prettified_content:
-                print('File {} is not pretty-formatted'.format(toml_file))
+                print("File {} is not pretty-formatted".format(toml_file))
 
                 if args.autofix:
-                    print('Fixing file {}'.format(toml_file))
-                    with io.open(toml_file, 'w', encoding='UTF-8') as f:
+                    print("Fixing file {}".format(toml_file))
+                    with io.open(toml_file, "w", encoding="UTF-8") as f:
                         f.write(prettified_content)
 
                 status = 1
         except TomlDecodeError:
-            print('Input File {} is not a valid TOML file'.format(toml_file))
+            print("Input File {} is not a valid TOML file".format(toml_file))
             return 1
 
     return status
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pretty_format_toml())

--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -40,28 +40,25 @@ def _process_single_document(document, yaml):
 def pretty_format_yaml(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '--autofix',
-        action='store_true',
-        dest='autofix',
-        help='Automatically fixes encountered not-pretty-formatted files',
+        "--autofix",
+        action="store_true",
+        dest="autofix",
+        help="Automatically fixes encountered not-pretty-formatted files",
     )
     parser.add_argument(
-        '--indent',
+        "--indent",
         type=int,
-        default='2',
-        help=(
-            'The number of indent spaces or a string to be used as delimiter'
-            ' for indentation level e.g. 4 or "\t" (Default: 2)'
-        ),
+        default="2",
+        help=("The number of indent spaces or a string to be used as delimiter" ' for indentation level e.g. 4 or "\t" (Default: 2)'),
     )
     parser.add_argument(
-        '--preserve-quotes',
-        action='store_true',
-        dest='preserve_quotes',
-        help='Keep existing string quoting',
+        "--preserve-quotes",
+        action="store_true",
+        dest="preserve_quotes",
+        help="Keep existing string quoting",
     )
 
-    parser.add_argument('filenames', nargs='*', help='Filenames to fix')
+    parser.add_argument("filenames", nargs="*", help="Filenames to fix")
     args = parser.parse_args(argv)
 
     status = 0
@@ -72,22 +69,22 @@ def pretty_format_yaml(argv=None):
     # Prevent ruamel.yaml to wrap yaml lines
     yaml.width = maxsize
 
-    separator = '---\n'
+    separator = "---\n"
 
     for yaml_file in set(args.filenames):
         with open(yaml_file) as f:
-            string_content = ''.join(f.readlines())
+            string_content = "".join(f.readlines())
 
         # Split multi-document file into individual documents
         #
         # Not using yaml.load_all() because it reformats primitive (non-YAML) content. It removes
         # newline characters.
-        separator_pattern = r'^---\s*\n'
+        separator_pattern = r"^---\s*\n"
         original_docs = re.split(separator_pattern, string_content, flags=re.MULTILINE)
 
         # A valid multi-document YAML file might starts with the separator.
         # In this case the first document of original docs will be empty and should not be consdered
-        if string_content.startswith('---'):
+        if string_content.startswith("---"):
             original_docs = original_docs[1:]
 
         pretty_docs = []
@@ -99,21 +96,21 @@ def pretty_format_yaml(argv=None):
                     pretty_docs.append(content)
 
             # Start multi-doc file with separator
-            pretty_content = '' if len(pretty_docs) == 1 else separator
+            pretty_content = "" if len(pretty_docs) == 1 else separator
             pretty_content += separator.join(pretty_docs)
 
             if string_content != pretty_content:
-                print('File {} is not pretty-formatted'.format(yaml_file))
+                print("File {} is not pretty-formatted".format(yaml_file))
 
                 if args.autofix:
-                    print('Fixing file {}'.format(yaml_file))
-                    with io.open(yaml_file, 'w', encoding='UTF-8') as f:
+                    print("Fixing file {}".format(yaml_file))
+                    with io.open(yaml_file, "w", encoding="UTF-8") as f:
                         f.write(text_type(pretty_content))
 
                 status = 1
         except YAMLError:  # pragma: no cover
             print(
-                'Input File {} is not a valid YAML file, consider using check-yaml'.format(
+                "Input File {} is not a valid YAML file, consider using check-yaml".format(
                     yaml_file,
                 ),
             )
@@ -122,5 +119,5 @@ def pretty_format_yaml(argv=None):
     return status
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(pretty_format_yaml())

--- a/language_formatters_pre_commit_hooks/utils.py
+++ b/language_formatters_pre_commit_hooks/utils.py
@@ -14,17 +14,20 @@ from six.moves.urllib.parse import urlparse
 
 
 def run_command(command):
-    print('[cwd={cwd}] Run command: {command}'.format(command=command, cwd=os.getcwd()), file=sys.stderr)
+    print("[cwd={cwd}] Run command: {command}".format(command=command, cwd=os.getcwd()), file=sys.stderr)
     return_code, output = None, None
     try:
-        return_code, output = 0, subprocess.check_output(
-            command,
-            stderr=subprocess.STDOUT,
-            shell=True,
-        ).decode('utf-8')
+        return_code, output = (
+            0,
+            subprocess.check_output(
+                command,
+                stderr=subprocess.STDOUT,
+                shell=True,
+            ).decode("utf-8"),
+        )
     except subprocess.CalledProcessError as e:
-        return_code, output = e.returncode, e.output.decode('utf-8')
-    print('[return_code={return_code}] | {output}'.format(return_code=return_code, output=output), file=sys.stderr)
+        return_code, output = e.returncode, e.output.decode("utf-8")
+    print("[return_code={return_code}] | {output}".format(return_code=return_code, output=output), file=sys.stderr)
     return return_code, output
 
 
@@ -32,9 +35,10 @@ def _base_directory():
     # Extracted from pre-commit code:
     # https://github.com/pre-commit/pre-commit/blob/master/pre_commit/store.py
     return os.path.realpath(
-        os.environ.get('PRE_COMMIT_HOME') or os.path.join(
-            os.environ.get('XDG_CACHE_HOME') or os.path.expanduser('~/.cache'),
-            'pre-commit',
+        os.environ.get("PRE_COMMIT_HOME")
+        or os.path.join(
+            os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache"),
+            "pre-commit",
         ),
     )
 
@@ -56,7 +60,7 @@ def download_url(url, file_name=None):
         # command line, but it should never be possible if invoked
         # via `pre-commit` as it would ensure that the directories
         # are present
-        print('Unexisting base directory ({base_directory}). Creating it'.format(base_directory=base_directory), file=sys.stderr)
+        print("Unexisting base directory ({base_directory}). Creating it".format(base_directory=base_directory), file=sys.stderr)
         os.makedirs(base_directory)
 
     print("Downloading {url}".format(url=url), file=sys.stderr)
@@ -74,9 +78,6 @@ def download_url(url, file_name=None):
 
 
 def remove_trailing_whitespaces_and_set_new_line_ending(string):
-    return '{content}\n'.format(
-        content='\n'.join(
-            line.rstrip()
-            for line in string.splitlines()
-        ).rstrip(),
+    return "{content}\n".format(
+        content="\n".join(line.rstrip() for line in string.splitlines()).rstrip(),
     )

--- a/setup.py
+++ b/setup.py
@@ -8,14 +8,14 @@ from setuptools import setup
 
 setup(
     entry_points={
-        'console_scripts': [
-            'pretty-format-golang = language_formatters_pre_commit_hooks.pretty_format_golang:pretty_format_golang',
-            'pretty-format-java = language_formatters_pre_commit_hooks.pretty_format_java:pretty_format_java',
-            'pretty-format-kotlin = language_formatters_pre_commit_hooks.pretty_format_kotlin:pretty_format_kotlin',
-            'pretty-format-ini = language_formatters_pre_commit_hooks.pretty_format_ini:pretty_format_ini',
-            'pretty-format-rust = language_formatters_pre_commit_hooks.pretty_format_rust:pretty_format_rust',
-            'pretty-format-toml = language_formatters_pre_commit_hooks.pretty_format_toml:pretty_format_toml',
-            'pretty-format-yaml = language_formatters_pre_commit_hooks.pretty_format_yaml:pretty_format_yaml',
+        "console_scripts": [
+            "pretty-format-golang = language_formatters_pre_commit_hooks.pretty_format_golang:pretty_format_golang",
+            "pretty-format-java = language_formatters_pre_commit_hooks.pretty_format_java:pretty_format_java",
+            "pretty-format-kotlin = language_formatters_pre_commit_hooks.pretty_format_kotlin:pretty_format_kotlin",
+            "pretty-format-ini = language_formatters_pre_commit_hooks.pretty_format_ini:pretty_format_ini",
+            "pretty-format-rust = language_formatters_pre_commit_hooks.pretty_format_rust:pretty_format_rust",
+            "pretty-format-toml = language_formatters_pre_commit_hooks.pretty_format_toml:pretty_format_toml",
+            "pretty-format-yaml = language_formatters_pre_commit_hooks.pretty_format_yaml:pretty_format_yaml",
         ],
     },
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,6 @@ def change_dir_context(directory):
 @contextmanager
 def undecorate_function(func):
     passed_function = func
-    func = getattr(passed_function, '__wrapped__', passed_function)
+    func = getattr(passed_function, "__wrapped__", passed_function)
     yield func
     func = passed_function

--- a/tests/pre_conditions_test.py
+++ b/tests/pre_conditions_test.py
@@ -15,7 +15,7 @@ from language_formatters_pre_commit_hooks.pre_conditions import rust_required
 @pytest.fixture(params=[True, False])
 def success(request):
     with mock.patch(
-        'language_formatters_pre_commit_hooks.pre_conditions.run_command',
+        "language_formatters_pre_commit_hooks.pre_conditions.run_command",
         autospec=True,
         return_value=(0 if request.param else 1, None),
     ):
@@ -25,22 +25,22 @@ def success(request):
 def test___assert_command_succeed(success):
     raised_exception = None
     try:
-        _assert_command_succeed('command', 'assert_message')
+        _assert_command_succeed("command", "assert_message")
     except AssertionError as e:
         raised_exception = e
 
     if success:
         assert raised_exception is None
     else:
-        assert isinstance(raised_exception, AssertionError) and 'assert_message' == str(raised_exception)
+        assert isinstance(raised_exception, AssertionError) and "assert_message" == str(raised_exception)
 
 
 @pytest.mark.parametrize(
-    'decorator, assert_content',
+    "decorator, assert_content",
     [
-        [java_required, 'JRE is required'],
-        [golang_required, 'golang/gofmt is required'],
-        [rust_required, 'rustfmt is required'],
+        [java_required, "JRE is required"],
+        [golang_required, "golang/gofmt is required"],
+        [rust_required, "rustfmt is required"],
     ],
 )
 def test_tool_required(success, decorator, assert_content):

--- a/tests/pretty_format_golang_test.py
+++ b/tests/pretty_format_golang_test.py
@@ -16,7 +16,7 @@ from tests.conftest import undecorate_function
 
 @pytest.fixture(autouse=True)
 def change_dir():
-    with change_dir_context('test-data/pretty_format_golang/'):
+    with change_dir_context("test-data/pretty_format_golang/"):
         yield
 
 
@@ -28,9 +28,10 @@ def undecorate_method():
 
 
 @pytest.mark.parametrize(
-    ('filename', 'expected_retval'), (
-        ('valid.go', 0),
-        ('invalid.go', 1),
+    ("filename", "expected_retval"),
+    (
+        ("valid.go", 0),
+        ("invalid.go", 1),
     ),
 )
 def test_pretty_format_golang(undecorate_method, filename, expected_retval):
@@ -38,12 +39,12 @@ def test_pretty_format_golang(undecorate_method, filename, expected_retval):
 
 
 def test_pretty_format_golang_autofix(tmpdir, undecorate_method):
-    srcfile = tmpdir.join('to_be_fixed.go')
+    srcfile = tmpdir.join("to_be_fixed.go")
     shutil.copyfile(
-        'invalid.go',
+        "invalid.go",
         srcfile.strpath,
     )
-    assert undecorate_method(['--autofix', srcfile.strpath]) == 1
+    assert undecorate_method(["--autofix", srcfile.strpath]) == 1
 
     # file was formatted (shouldn't trigger linter again)
     ret = undecorate_method([srcfile.strpath])
@@ -51,14 +52,14 @@ def test_pretty_format_golang_autofix(tmpdir, undecorate_method):
 
 
 @pytest.mark.parametrize(
-    'exit_status, output, expected_eol',
+    "exit_status, output, expected_eol",
     [
-        (1, '', None),
-        (0, '', None),
-        (0, 'a\0eol\0lf\0', 'lf'),
+        (1, "", None),
+        (0, "", None),
+        (0, "a\0eol\0lf\0", "lf"),
     ],
 )
-@patch('language_formatters_pre_commit_hooks.pretty_format_golang.run_command', autospec=True)
+@patch("language_formatters_pre_commit_hooks.pretty_format_golang.run_command", autospec=True)
 def test__get_eol_attribute(mock_run_command, exit_status, output, expected_eol):
     mock_run_command.return_value = (exit_status, output)
     assert _get_eol_attribute() == expected_eol

--- a/tests/pretty_format_ini_test.py
+++ b/tests/pretty_format_ini_test.py
@@ -16,23 +16,25 @@ from language_formatters_pre_commit_hooks.pretty_format_ini import pretty_format
 def change_dir():
     working_directory = os.getcwd()
     try:
-        os.chdir('test-data/pretty_format_ini/')
+        os.chdir("test-data/pretty_format_ini/")
         yield
     finally:
         os.chdir(working_directory)
 
 
 @pytest.mark.parametrize(
-    ('filename', 'expected_retval'), (
+    ("filename", "expected_retval"),
+    (
         pytest.param(
-            'pretty-formatted.ini', 0,
+            "pretty-formatted.ini",
+            0,
             marks=pytest.mark.xfail(
                 condition=not six.PY3,
-                reason='ConfigParser writing format has changed between Python2 and Python3, let\'s test it only once',
+                reason="ConfigParser writing format has changed between Python2 and Python3, let's test it only once",
             ),
         ),
-        ('not-pretty-formatted.ini', 1),
-        ('not-valid-file.ini', 1),
+        ("not-pretty-formatted.ini", 1),
+        ("not-valid-file.ini", 1),
     ),
 )
 def test_pretty_format_ini(filename, expected_retval):
@@ -40,12 +42,12 @@ def test_pretty_format_ini(filename, expected_retval):
 
 
 def test_pretty_format_ini_autofix(tmpdir):
-    srcfile = tmpdir.join('to_be_fixed.ini')
+    srcfile = tmpdir.join("to_be_fixed.ini")
     shutil.copyfile(
-        'not-pretty-formatted.ini',
+        "not-pretty-formatted.ini",
         srcfile.strpath,
     )
-    assert pretty_format_ini(['--autofix', srcfile.strpath]) == 1
+    assert pretty_format_ini(["--autofix", srcfile.strpath]) == 1
 
     # file was formatted (shouldn't trigger linter again)
     ret = pretty_format_ini([srcfile.strpath])

--- a/tests/pretty_format_java_test.py
+++ b/tests/pretty_format_java_test.py
@@ -14,7 +14,7 @@ from tests.conftest import undecorate_function
 
 @pytest.fixture(autouse=True)
 def change_dir():
-    with change_dir_context('test-data/pretty_format_java/'):
+    with change_dir_context("test-data/pretty_format_java/"):
         yield
 
 
@@ -26,9 +26,10 @@ def undecorate_method():
 
 
 @pytest.mark.parametrize(
-    ('filename', 'expected_retval'), (
-        ('valid.java', 0),
-        ('invalid.java', 1),
+    ("filename", "expected_retval"),
+    (
+        ("valid.java", 0),
+        ("invalid.java", 1),
     ),
 )
 def test_pretty_format_java(undecorate_method, filename, expected_retval):
@@ -36,12 +37,12 @@ def test_pretty_format_java(undecorate_method, filename, expected_retval):
 
 
 def test_pretty_format_java_autofix(tmpdir, undecorate_method):
-    srcfile = tmpdir.join('to_be_fixed.java')
+    srcfile = tmpdir.join("to_be_fixed.java")
     shutil.copyfile(
-        'invalid.java',
+        "invalid.java",
         srcfile.strpath,
     )
-    assert undecorate_method(['--autofix', srcfile.strpath]) == 1
+    assert undecorate_method(["--autofix", srcfile.strpath]) == 1
 
     # file was formatted (shouldn't trigger linter again)
     ret = undecorate_method([srcfile.strpath])

--- a/tests/pretty_format_kotlin_test.py
+++ b/tests/pretty_format_kotlin_test.py
@@ -14,7 +14,7 @@ from tests.conftest import undecorate_function
 
 @pytest.fixture(autouse=True)
 def change_dir():
-    with change_dir_context('test-data/pretty_format_kotlin/'):
+    with change_dir_context("test-data/pretty_format_kotlin/"):
         yield
 
 
@@ -26,9 +26,10 @@ def undecorate_method():
 
 
 @pytest.mark.parametrize(
-    ('filename', 'expected_retval'), (
-        ('valid.kt', 0),
-        ('invalid.kt', 1),
+    ("filename", "expected_retval"),
+    (
+        ("valid.kt", 0),
+        ("invalid.kt", 1),
     ),
 )
 def test_pretty_format_kotlin(undecorate_method, filename, expected_retval):
@@ -36,13 +37,13 @@ def test_pretty_format_kotlin(undecorate_method, filename, expected_retval):
 
 
 def test_pretty_format_kotlin_autofix(tmpdir, undecorate_method):
-    srcfile = tmpdir.join('to_be_fixed.kt')
+    srcfile = tmpdir.join("to_be_fixed.kt")
     shutil.copyfile(
-        'invalid.kt',
+        "invalid.kt",
         srcfile.strpath,
     )
     with change_dir_context(tmpdir.dirname):
-        assert undecorate_method(['--autofix', srcfile.strpath]) == 1
+        assert undecorate_method(["--autofix", srcfile.strpath]) == 1
 
         # file was formatted (shouldn't trigger linter again)
         ret = undecorate_method([srcfile.strpath])

--- a/tests/pretty_format_rust_test.py
+++ b/tests/pretty_format_rust_test.py
@@ -15,7 +15,7 @@ from tests.conftest import undecorate_function
 
 @pytest.fixture(autouse=True)
 def change_dir():
-    with change_dir_context('test-data/pretty_format_rust/'):
+    with change_dir_context("test-data/pretty_format_rust/"):
         yield
 
 
@@ -27,9 +27,10 @@ def undecorate_method():
 
 
 @pytest.mark.parametrize(
-    ('filename', 'expected_retval'), (
-        ('valid/src/main.rs', 0),
-        ('invalid/src/main.rs', 1),
+    ("filename", "expected_retval"),
+    (
+        ("valid/src/main.rs", 0),
+        ("invalid/src/main.rs", 1),
     ),
 )
 def test_pretty_format_rust(undecorate_method, filename, expected_retval):
@@ -39,15 +40,15 @@ def test_pretty_format_rust(undecorate_method, filename, expected_retval):
 
 
 def test_pretty_format_rust_autofix(tmpdir, undecorate_method):
-    cargo_file = tmpdir.join('Cargo.toml')
-    shutil.copyfile('invalid/Cargo.toml', cargo_file.strpath)
+    cargo_file = tmpdir.join("Cargo.toml")
+    shutil.copyfile("invalid/Cargo.toml", cargo_file.strpath)
 
-    tmpdir.mkdir('src')
-    src_file = tmpdir.join('src', 'main.rs')
-    shutil.copyfile('invalid/src/main.rs', src_file.strpath)
+    tmpdir.mkdir("src")
+    src_file = tmpdir.join("src", "main.rs")
+    shutil.copyfile("invalid/src/main.rs", src_file.strpath)
 
     with change_dir_context(tmpdir.strpath):
-        assert undecorate_method(['--autofix', src_file.strpath]) == 1
+        assert undecorate_method(["--autofix", src_file.strpath]) == 1
 
         # file was formatted (shouldn't trigger linter again)
         ret = undecorate_method([src_file.strpath])

--- a/tests/pretty_format_toml_test.py
+++ b/tests/pretty_format_toml_test.py
@@ -15,17 +15,18 @@ from language_formatters_pre_commit_hooks.pretty_format_toml import pretty_forma
 def change_dir():
     working_directory = os.getcwd()
     try:
-        os.chdir('test-data/pretty_format_toml/')
+        os.chdir("test-data/pretty_format_toml/")
         yield
     finally:
         os.chdir(working_directory)
 
 
 @pytest.mark.parametrize(
-    ('filename', 'expected_retval'), (
-        ('pretty-formatted.toml', 0),
-        ('not-pretty-formatted.toml', 1),
-        ('not-valid-file.toml', 1),
+    ("filename", "expected_retval"),
+    (
+        ("pretty-formatted.toml", 0),
+        ("not-pretty-formatted.toml", 1),
+        ("not-valid-file.toml", 1),
     ),
 )
 def test_pretty_format_toml(filename, expected_retval):
@@ -33,12 +34,12 @@ def test_pretty_format_toml(filename, expected_retval):
 
 
 def test_pretty_format_toml_autofix(tmpdir):
-    srcfile = tmpdir.join('to_be_fixed.toml')
+    srcfile = tmpdir.join("to_be_fixed.toml")
     shutil.copyfile(
-        'not-pretty-formatted.toml',
+        "not-pretty-formatted.toml",
         srcfile.strpath,
     )
-    assert pretty_format_toml(['--autofix', srcfile.strpath]) == 1
+    assert pretty_format_toml(["--autofix", srcfile.strpath]) == 1
 
     # file was formatted (shouldn't trigger linter again)
     ret = pretty_format_toml([srcfile.strpath])

--- a/tests/pretty_format_yaml_test.py
+++ b/tests/pretty_format_yaml_test.py
@@ -15,24 +15,25 @@ from language_formatters_pre_commit_hooks.pretty_format_yaml import pretty_forma
 def change_dir():
     working_directory = os.getcwd()
     try:
-        os.chdir('test-data/pretty_format_yaml/')
+        os.chdir("test-data/pretty_format_yaml/")
         yield
     finally:
         os.chdir(working_directory)
 
 
 @pytest.mark.parametrize(
-    ('filename', 'expected_retval'), (
-        ('pretty-formatted.yaml', 0),
-        ('not-pretty-formatted.yaml', 1),
-        ('multi-doc-pretty-formatted.yaml', 0),
-        ('multi-doc-not-pretty-formatted.yaml', 1),
-        ('not-valid-file.yaml', 1),
-        ('ansible-vault.yaml', 0),
-        ('primitive.yaml', 0),
-        ('empty-doc-with-separator.yaml', 1),
-        ('empty-doc.yaml', 0),
-        ('multi-doc-with-empty-document-inside.yaml', 0),
+    ("filename", "expected_retval"),
+    (
+        ("pretty-formatted.yaml", 0),
+        ("not-pretty-formatted.yaml", 1),
+        ("multi-doc-pretty-formatted.yaml", 0),
+        ("multi-doc-not-pretty-formatted.yaml", 1),
+        ("not-valid-file.yaml", 1),
+        ("ansible-vault.yaml", 0),
+        ("primitive.yaml", 0),
+        ("empty-doc-with-separator.yaml", 1),
+        ("empty-doc.yaml", 0),
+        ("multi-doc-with-empty-document-inside.yaml", 0),
     ),
 )
 def test_pretty_format_yaml(filename, expected_retval):
@@ -40,18 +41,19 @@ def test_pretty_format_yaml(filename, expected_retval):
 
 
 @pytest.mark.parametrize(
-    ('no_pretty_file_name'), (
-        ('not-pretty-formatted.yaml'),
-        ('multi-doc-not-pretty-formatted.yaml'),
+    ("no_pretty_file_name"),
+    (
+        ("not-pretty-formatted.yaml"),
+        ("multi-doc-not-pretty-formatted.yaml"),
     ),
 )
 def test_pretty_format_yaml_autofix(tmpdir, no_pretty_file_name):
-    srcfile = tmpdir.join('to_be_fixed.yaml')
+    srcfile = tmpdir.join("to_be_fixed.yaml")
     shutil.copyfile(
         no_pretty_file_name,
         srcfile.strpath,
     )
-    assert pretty_format_yaml(['--autofix', srcfile.strpath]) == 1
+    assert pretty_format_yaml(["--autofix", srcfile.strpath]) == 1
 
     # file was formatted (shouldn't trigger linter again)
     ret = pretty_format_yaml([srcfile.strpath])
@@ -59,6 +61,6 @@ def test_pretty_format_yaml_autofix(tmpdir, no_pretty_file_name):
 
 
 def test_pretty_format_yaml_preserve_quotes():
-    filename = 'preserve-quotes-pretty-formatted.yaml'
+    filename = "preserve-quotes-pretty-formatted.yaml"
     assert pretty_format_yaml([filename]) == 1
-    assert pretty_format_yaml(['--preserve-quotes', filename]) == 0
+    assert pretty_format_yaml(["--preserve-quotes", filename]) == 0

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -17,19 +17,23 @@ from language_formatters_pre_commit_hooks.utils import run_command
 
 
 @pytest.mark.parametrize(
-    'command, expected_status, expected_output',
+    "command, expected_status, expected_output",
     [
-        ('echo 1', 0, '1{}'.format(os.linesep)),
+        ("echo 1", 0, "1{}".format(os.linesep)),
         pytest.param(
-            'echo 1 | grep 0', 1, '',
-            marks=pytest.mark.skipif(condition=sys.platform == 'win32', reason='Windows does not have `grep`'),
+            "echo 1 | grep 0",
+            1,
+            "",
+            marks=pytest.mark.skipif(condition=sys.platform == "win32", reason="Windows does not have `grep`"),
         ),
         pytest.param(
-            'echo 1 | findstr 0', 1, '',
-            marks=pytest.mark.skipif(condition=sys.platform != 'win32', reason='Linux and MacOS does not have `findstr`'),
+            "echo 1 | findstr 0",
+            1,
+            "",
+            marks=pytest.mark.skipif(condition=sys.platform != "win32", reason="Linux and MacOS does not have `findstr`"),
         ),
-        ['true', 0, ''],
-        ['false', 1, ''],
+        ["true", 0, ""],
+        ["false", 1, ""],
     ],
 )
 def test_run_command(command, expected_status, expected_output):
@@ -37,20 +41,20 @@ def test_run_command(command, expected_status, expected_output):
 
 
 @pytest.mark.parametrize(
-    'url, does_file_already_exist',
+    "url, does_file_already_exist",
     [
-        [urljoin('file://', pathname2url(__file__)), True],
-        [urljoin('file://', pathname2url(__file__)), False],
+        [urljoin("file://", pathname2url(__file__)), True],
+        [urljoin("file://", pathname2url(__file__)), False],
     ],
 )
-@mock.patch('language_formatters_pre_commit_hooks.utils.shutil', autospec=True)
-@mock.patch('language_formatters_pre_commit_hooks.utils.requests', autospec=True)
+@mock.patch("language_formatters_pre_commit_hooks.utils.shutil", autospec=True)
+@mock.patch("language_formatters_pre_commit_hooks.utils.requests", autospec=True)
 def test_download_url(mock_requests, mock_shutil, tmpdir, url, does_file_already_exist):
     if does_file_already_exist:
-        with open(os.path.join(tmpdir.strpath, basename(url)), 'w') as f:
-            f.write('')
+        with open(os.path.join(tmpdir.strpath, basename(url)), "w") as f:
+            f.write("")
 
-    with mock.patch.dict(os.environ, {'PRE_COMMIT_HOME': tmpdir.strpath}):
+    with mock.patch.dict(os.environ, {"PRE_COMMIT_HOME": tmpdir.strpath}):
         assert download_url(url) == os.path.join(tmpdir.strpath, basename(url))
 
     if does_file_already_exist:

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 [tox]
 # These should match the travis env list
-envlist = py27,py36,py37,pre-commit
+envlist = py{27,36,37,38},pre-commit
 
 [gh-actions]
 python =
     2.7: py27
     3.6: py36
     3.7: py37
+    3.8: py38
 
 [testenv]
 deps = -rrequirements-dev.txt
@@ -32,7 +33,7 @@ envdir = {toxinidir}/venv
 commands =
 
 [flake8]
-max-line-length=141
-
-[pep8]
-ignore=E265,E501
+ignore = E203, E266, E501, W503, F403, F401
+max-line-length = 141
+max-complexity = 18
+select = B,C,E,F,W,T4,B9


### PR DESCRIPTION
The goal of this PR is to revamp the pre-commit enforced on the repository, including the usage of [black](https://github.com/psf/black) uncompromising code formatter.

The PR is split into two commits:
 * the first (07d7e65) providing the pre-commit changes: noticeably it defaults the usage of python3.7 for pre-commit and black is configured (preserve python2.7 compatibility)
 * the second (40f5979) applies the pre-commit provided changes (`pre-commit run --all-files`)