### PR TITLE
Bump ktlint release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 unreleased (YYYY-MM-DD)
 -----------------------
 
-- Update KTLint to 0.38.1
+- Update KTLint to 0.39.0
 - Update GoogleJavaFormatter to 1.9
 - Run `pretty-format-java` serially to prevent multiple-downloads of the same Java artifact. [PR #23](https://github.com/macisamuele/language-formatters-pre-commit-hooks/pull/23) - [@ineiti](https://github.com/ineiti) thanks for your contribution
 - Internal update of download logic to reduce race coditions while download big artifacts from network. [PR #24](https://github.com/macisamuele/language-formatters-pre-commit-hooks/pull/24)

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,6 @@ endif
 bump-download-releases: export KLINT_VERSION = $(shell curl --silent https://api.github.com/repos/pinterest/ktlint/releases/latest | jq -r .name)
 bump-download-releases: export GOOGLE_JAVA_FORMATTER_VERSION = $(shell curl --silent https://api.github.com/repos/google/google-java-format/releases/latest | jq -r .name)
 bump-download-releases:
-	sed -ri "s/(KTLINT_VERSION = )'.*'/\1'${KLINT_VERSION}'/" language_formatters_pre_commit_hooks/pretty_format_kotlin.py
-	sed -ri "s/(GOOGLE_JAVA_FORMATTER_VERSION = )'.*'/\1'${GOOGLE_JAVA_FORMATTER_VERSION}'/" language_formatters_pre_commit_hooks/pretty_format_java.py
+	sed -ri 's/(__KTLINT_VERSION = ).*/\1"${KLINT_VERSION}"/' language_formatters_pre_commit_hooks/pretty_format_kotlin.py
+	sed -ri 's/(__GOOGLE_JAVA_FORMATTER_VERSION = ).*/\1"${GOOGLE_JAVA_FORMATTER_VERSION}"/' language_formatters_pre_commit_hooks/pretty_format_java.py
 	git add --patch language_formatters_pre_commit_hooks/pretty_format_kotlin.py language_formatters_pre_commit_hooks/pretty_format_java.py

--- a/language_formatters_pre_commit_hooks/pretty_format_java.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_java.py
@@ -11,7 +11,7 @@ from language_formatters_pre_commit_hooks.utils import download_url
 from language_formatters_pre_commit_hooks.utils import run_command
 
 
-__GOOGLE_JAVA_FORMATTER_VERSION = '1.9'
+__GOOGLE_JAVA_FORMATTER_VERSION = "1.9"
 
 
 def __download_google_java_formatter_jar(version):  # pragma: no cover

--- a/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
@@ -11,7 +11,7 @@ from language_formatters_pre_commit_hooks.utils import download_url
 from language_formatters_pre_commit_hooks.utils import run_command
 
 
-__KTLINT_VERSION = '0.38.1'
+__KTLINT_VERSION = "0.39.0"
 
 
 def __download_kotlin_formatter_jar(version):  # pragma: no cover


### PR DESCRIPTION
As from the title, this PR bumps the default used KTlint version to the latest release and fixes the `bump-download-releases` makefile target (that was broken by #30 )