### PR TITLE
Define type annotations

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,12 +1,14 @@
 [report]
 exclude_lines =
-	except [^ ]+ as ignore:
+	pass
     def __repr__
+    except [^ ]+ as ignore:
+    if __name__ == .__main__.:
+    if getattr\(typing, "TYPE_CHECKING", False\):
+    if typing.TYPE_CHECKING:
+    pragma: no cover
     raise AssertionError
     raise NotImplementedError
-    if __name__ == .__main__.:
-    pragma: no cover
-	pass
 fail_under = 100
 show_missing = True
 skip_covered = True

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+!/.coveragerc/
 *.egg-info/
 *.pyc
 /.coverage*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /dist/
 /venv/
 __pycache__/
+/.mypy_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,3 +57,4 @@ repos:
   rev: v0.782
   hooks:
   - id: mypy
+    exclude: ^(\.github/workflows/bump_external_releases\.py)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,3 +53,7 @@ repos:
   rev: 3.8.3
   hooks:
   - id: flake8
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.782
+  hooks:
+  - id: mypy

--- a/language_formatters_pre_commit_hooks/__init__.py
+++ b/language_formatters_pre_commit_hooks/__init__.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+
 import pkg_resources
 
 
@@ -10,6 +12,7 @@ __version__ = pkg_resources.get_distribution("language_formatters_pre_commit_hoo
 
 
 def _get_default_version(tool_name):  # pragma: no cover
+    # type: (typing.Text) -> typing.Text
     """
     Read tool_name default version.
     The method is intended to be used only from language_formatters_pre_commit_hooks modules

--- a/language_formatters_pre_commit_hooks/pre_conditions.py
+++ b/language_formatters_pre_commit_hooks/pre_conditions.py
@@ -3,58 +3,83 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import typing
+from functools import wraps
 from os import getenv
-
-from decorator import decorator
 
 from language_formatters_pre_commit_hooks.utils import run_command
 
-_DEFAULT_MESSAGE_TEMPLATE = (
-    "{required_tool} is required to run this pre-commit hook. "
-    "Make sure that you have it installed and available on your path.\n"
-    "Download/Install URL: {install_url}"
+
+if getattr(typing, "TYPE_CHECKING", False):
+    F = typing.TypeVar("F", bound=typing.Callable[..., int])
+
+
+def _is_command_success(*command_args):
+    # type: (typing.Text) -> bool
+    exit_status, _ = run_command(" ".join(command_args))
+    return exit_status == 0
+
+
+class ToolNotInstalled(RuntimeError):
+    def __init__(self, tool_name, download_install_url):
+        # type: (typing.Text, typing.Text) -> None
+        self.tool_name = tool_name
+        self.download_install_url = download_install_url
+
+    def __str__(self):
+        # type: () -> str
+        return str(
+            "{tool_name} is required to run this pre-commit hook.\n"
+            "Make sure that you have it installed and available on your path.\n"
+            "Download/Install URL: {download_install_url}".format(
+                tool_name=self.tool_name,
+                download_install_url=self.download_install_url,
+            )
+        )
+
+
+class _ToolRequired(object):
+    def __init__(self, tool_name, check_command, download_install_url):
+        # type: (typing.Text, typing.Callable[[], bool], typing.Text) -> None
+        self.tool_name = tool_name
+        self.check_command = check_command
+        self.download_install_url = download_install_url
+
+    def is_tool_installed(self):
+        # type: () -> bool
+        return self.check_command()
+
+    def __call__(self, f):
+        # type: (F) -> F
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            # type: (typing.Any, typing.Any) -> int
+            if not self.is_tool_installed():
+                raise ToolNotInstalled(
+                    tool_name=self.tool_name,
+                    download_install_url=self.download_install_url,
+                )
+
+            return f(*args, **kwargs)
+
+        return wrapper  # type: ignore
+
+
+java_required = _ToolRequired(
+    tool_name="JRE",
+    check_command=lambda: _is_command_success("java", "-version"),
+    download_install_url="https://www.java.com/en/download/",
+)
+
+golang_required = _ToolRequired(
+    tool_name="golang/gofmt",
+    check_command=lambda: _is_command_success("go", "version"),
+    download_install_url="https://golang.org/doc/install#download",
 )
 
 
-def _assert_command_succeed(command, assertion_error_message):
-    status, _ = run_command(command)
-    assert status == 0, assertion_error_message
-
-
-@decorator
-def java_required(f, *args, **kwargs):
-    _assert_command_succeed(
-        command="java -version",
-        assertion_error_message=_DEFAULT_MESSAGE_TEMPLATE.format(
-            required_tool="JRE",
-            install_url="https://www.java.com/en/download/",
-        ),
-    )
-    return f(*args, **kwargs)
-
-
-@decorator
-def golang_required(f, *args, **kwargs):
-    _assert_command_succeed(
-        command="go version",
-        assertion_error_message=_DEFAULT_MESSAGE_TEMPLATE.format(
-            required_tool="golang/gofmt",
-            install_url="https://golang.org/doc/install#download",
-        ),
-    )
-
-    return f(*args, **kwargs)
-
-
-@decorator
-def rust_required(f, *args, **kwargs):
-    rust_toolchain_version = getenv("RUST_TOOLCHAIN", "stable")
-    _assert_command_succeed(
-        command="cargo +{} fmt  -- --version".format(rust_toolchain_version),
-        assertion_error_message=_DEFAULT_MESSAGE_TEMPLATE.format(
-            required_tool="rustfmt",
-            install_url="https://github.com/rust-lang-nursery/rustfmt#quick-start",
-        ),
-    )
-
-    return f(*args, **kwargs)
+rust_required = _ToolRequired(
+    tool_name="rustfmt",
+    check_command=(lambda: _is_command_success("cargo", "+{}".format(getenv("RUST_TOOLCHAIN", "stable")), "fmt", "--", "--version")),
+    download_install_url="https://github.com/rust-lang-nursery/rustfmt#quick-start",
+)

--- a/language_formatters_pre_commit_hooks/pretty_format_golang.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_golang.py
@@ -5,12 +5,14 @@ from __future__ import unicode_literals
 
 import argparse
 import sys
+import typing
 
 from language_formatters_pre_commit_hooks.pre_conditions import golang_required
 from language_formatters_pre_commit_hooks.utils import run_command
 
 
 def _get_eol_attribute():
+    # type: () -> typing.Optional[typing.Text]
     """
     Retrieve eol attribute defined for golang files
     The method will return None in case of any error interacting with git
@@ -35,6 +37,7 @@ def _get_eol_attribute():
 
 @golang_required
 def pretty_format_golang(argv=None):
+    # type: (typing.Optional[typing.List[typing.Text]]) -> int
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",

--- a/language_formatters_pre_commit_hooks/pretty_format_ini.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_ini.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import argparse
 import io
 import sys
+import typing
 
 from six import PY3
 from six import StringIO
@@ -17,6 +18,7 @@ from language_formatters_pre_commit_hooks.utils import remove_trailing_whitespac
 
 
 def pretty_format_ini(argv=None):
+    # type: (typing.Optional[typing.List[typing.Text]]) -> int
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",
@@ -31,15 +33,15 @@ def pretty_format_ini(argv=None):
     status = 0
 
     for ini_file in set(args.filenames):
-        with open(ini_file) as f:
-            string_content = "".join(f.readlines())
+        with open(ini_file) as input_file:
+            string_content = "".join(input_file.readlines())
 
         config_parser = ConfigParser()
         try:
             if PY3:  # pragma: no cover # py3+ only
                 config_parser.read_string(string_content)
             else:  # pragma: no cover # py27 only
-                config_parser.readfp(StringIO(string_content))
+                config_parser.readfp(StringIO(str(string_content)))
 
             pretty_content = StringIO()
             config_parser.write(pretty_content)
@@ -53,8 +55,8 @@ def pretty_format_ini(argv=None):
 
                 if args.autofix:
                     print("Fixing file {}".format(ini_file))
-                    with io.open(ini_file, "w", encoding="UTF-8") as f:
-                        f.write(text_type(pretty_content_str))
+                    with io.open(ini_file, "w", encoding="UTF-8") as output_file:
+                        output_file.write(text_type(pretty_content_str))
 
                 status = 1
         except Error:

--- a/language_formatters_pre_commit_hooks/pretty_format_java.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_java.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import argparse
 import sys
+import typing
 
 from language_formatters_pre_commit_hooks import _get_default_version
 from language_formatters_pre_commit_hooks.pre_conditions import java_required
@@ -13,7 +14,9 @@ from language_formatters_pre_commit_hooks.utils import run_command
 
 
 def __download_google_java_formatter_jar(version):  # pragma: no cover
+    # type: (typing.Text) -> typing.Text
     def get_url(_version):
+        # type: (typing.Text) -> typing.Text
         # Links extracted from https://github.com/google/google-java-format/
         return (
             "https://github.com/google/google-java-format/releases/download/"
@@ -37,6 +40,7 @@ def __download_google_java_formatter_jar(version):  # pragma: no cover
 
 @java_required
 def pretty_format_java(argv=None):
+    # type: (typing.Optional[typing.List[typing.Text]]) -> int
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",

--- a/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import argparse
 import sys
+import typing
 
 from language_formatters_pre_commit_hooks import _get_default_version
 from language_formatters_pre_commit_hooks.pre_conditions import java_required
@@ -13,7 +14,9 @@ from language_formatters_pre_commit_hooks.utils import run_command
 
 
 def __download_kotlin_formatter_jar(version):  # pragma: no cover
+    # type: (typing.Text) -> typing.Text
     def get_url(_version):
+        # type: (typing.Text) -> typing.Text
         # Links extracted from https://github.com/pinterest/ktlint/
         return "https://github.com/pinterest/ktlint/releases/download/{version}/ktlint".format(
             version=_version,
@@ -34,6 +37,7 @@ def __download_kotlin_formatter_jar(version):  # pragma: no cover
 
 @java_required
 def pretty_format_kotlin(argv=None):
+    # type: (typing.Optional[typing.List[typing.Text]]) -> int
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",
@@ -66,7 +70,7 @@ def pretty_format_kotlin(argv=None):
         ),
     )
 
-    not_pretty_formatted_files = set()
+    not_pretty_formatted_files = set()  # type: typing.Set[typing.Text]
     if check_status != 0:
         not_pretty_formatted_files.update(line.split(":", 1)[0] for line in check_output.splitlines())
 

--- a/language_formatters_pre_commit_hooks/pretty_format_rust.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_rust.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import argparse
 import sys
+import typing
 from os import getenv
 
 from language_formatters_pre_commit_hooks.pre_conditions import rust_required
@@ -13,6 +14,7 @@ from language_formatters_pre_commit_hooks.utils import run_command
 
 @rust_required
 def pretty_format_rust(argv=None):
+    # type: (typing.Optional[typing.List[typing.Text]]) -> int
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",

--- a/language_formatters_pre_commit_hooks/pretty_format_toml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_toml.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import argparse
 import io
 import sys
+import typing
 
 from toml import dumps
 from toml import loads
@@ -15,6 +16,7 @@ from language_formatters_pre_commit_hooks.utils import remove_trailing_whitespac
 
 
 def pretty_format_toml(argv=None):
+    # type: (typing.Optional[typing.List[typing.Text]]) -> int
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",
@@ -29,8 +31,8 @@ def pretty_format_toml(argv=None):
     status = 0
 
     for toml_file in set(args.filenames):
-        with open(toml_file) as f:
-            string_content = "".join(f.readlines())
+        with open(toml_file) as input_file:
+            string_content = "".join(input_file.readlines())
 
         try:
             prettified_content = remove_trailing_whitespaces_and_set_new_line_ending(
@@ -42,8 +44,8 @@ def pretty_format_toml(argv=None):
 
                 if args.autofix:
                     print("Fixing file {}".format(toml_file))
-                    with io.open(toml_file, "w", encoding="UTF-8") as f:
-                        f.write(prettified_content)
+                    with io.open(toml_file, "w", encoding="UTF-8") as output_file:
+                        output_file.write(prettified_content)
 
                 status = 1
         except TomlDecodeError:

--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -7,6 +7,7 @@ import argparse
 import io
 import re
 import sys
+import typing
 from sys import maxsize
 
 from ruamel.yaml import YAML
@@ -16,6 +17,8 @@ from six import text_type
 
 
 def _process_single_document(document, yaml):
+    # type: (typing.Text, YAML) -> typing.Text
+
     """Pretty format one YAML document.
 
     This is needed in order to prevent `ruamel.yaml` to interfere with documents that have primitive types on the document root.
@@ -38,6 +41,7 @@ def _process_single_document(document, yaml):
 
 
 def pretty_format_yaml(argv=None):
+    # type: (typing.Optional[typing.List[typing.Text]]) -> int
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",
@@ -72,8 +76,8 @@ def pretty_format_yaml(argv=None):
     separator = "---\n"
 
     for yaml_file in set(args.filenames):
-        with open(yaml_file) as f:
-            string_content = "".join(f.readlines())
+        with open(yaml_file) as input_file:
+            string_content = "".join(input_file.readlines())
 
         # Split multi-document file into individual documents
         #
@@ -104,8 +108,8 @@ def pretty_format_yaml(argv=None):
 
                 if args.autofix:
                     print("Fixing file {}".format(yaml_file))
-                    with io.open(yaml_file, "w", encoding="UTF-8") as f:
-                        f.write(text_type(pretty_content))
+                    with io.open(yaml_file, "w", encoding="UTF-8") as output_file:
+                        output_file.write(text_type(pretty_content))
 
                 status = 1
         except YAMLError:  # pragma: no cover

--- a/language_formatters_pre_commit_hooks/utils.py
+++ b/language_formatters_pre_commit_hooks/utils.py
@@ -8,14 +8,16 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import typing
 
 import requests
 from six.moves.urllib.parse import urlparse
 
 
 def run_command(command):
+    # type: (typing.Text) -> typing.Tuple[int, typing.Text]
     print("[cwd={cwd}] Run command: {command}".format(command=command, cwd=os.getcwd()), file=sys.stderr)
-    return_code, output = None, None
+    return_code, output = 1, ""
     try:
         return_code, output = (
             0,
@@ -32,18 +34,20 @@ def run_command(command):
 
 
 def _base_directory():
+    # type: () -> typing.Text
     # Extracted from pre-commit code:
     # https://github.com/pre-commit/pre-commit/blob/master/pre_commit/store.py
     return os.path.realpath(
-        os.environ.get("PRE_COMMIT_HOME")
+        os.environ.get(str("PRE_COMMIT_HOME"))
         or os.path.join(
-            os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache"),
+            os.environ.get(str("XDG_CACHE_HOME")) or os.path.expanduser("~/.cache"),
             "pre-commit",
         ),
     )
 
 
 def download_url(url, file_name=None):
+    # type: (typing.Text, typing.Optional[typing.Text]) -> typing.Text
     base_directory = _base_directory()
 
     final_file = os.path.join(
@@ -78,6 +82,7 @@ def download_url(url, file_name=None):
 
 
 def remove_trailing_whitespaces_and_set_new_line_ending(string):
+    # type: (typing.Text) -> typing.Text
     return "{content}\n".format(
         content="\n".join(line.rstrip() for line in string.splitlines()).rstrip(),
     )

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,27 @@
+[mypy]
+ignore_missing_imports = True
+python_version = 2.7
+strict_optional = True
+warn_redundant_casts = True
+warn_unused_configs = True
+
+[mypy-tests.*]
+check_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_calls = False
+disallow_untyped_decorators = True
+no_implicit_optional = True
+warn_return_any = True
+warn_unused_ignores = True
+
+[mypy-language_formatters_pre_commit_hooks.*]
+check_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_subclassing_any = True
+disallow_untyped_calls = False
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+no_implicit_optional = True
+warn_return_any = True
+warn_unused_ignores = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ version = 1.5.0
 
 [options]
 install_requires =
-    decorator
     requests
     ruamel.yaml
     six

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ from setuptools import setup
 
 
 setup(
+    extras_require={
+        ":python_version<'3.5'": ["typing"],
+    },
     entry_points={
         "console_scripts": [
             "pretty-format-golang = language_formatters_pre_commit_hooks.pretty_format_golang:pretty_format_golang",

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -52,7 +52,7 @@ def test_run_command(command, expected_status, expected_output):
 def test_download_url(mock_requests, mock_shutil, tmpdir, url, does_file_already_exist):
     if does_file_already_exist:
         with open(os.path.join(tmpdir.strpath, basename(url)), "w") as f:
-            f.write("")
+            f.write(str(""))
 
     with mock.patch.dict(os.environ, {"PRE_COMMIT_HOME": tmpdir.strpath}):
         assert download_url(url) == os.path.join(tmpdir.strpath, basename(url))


### PR DESCRIPTION
The goal of this PR is to introduce type checking into the tool.
Type annotations are provided with "comment-style" such that we can still support Python2 (I know is deprecated, but costs us nothing to still support it).

The most interesting change that this PR provides is the change of the decorators offered by `pre_conditions` module.
The new decorator structure, behaves exactly how it was used to but it allows to have more accurate typing information defined.