### PR TITLE
[Security] Ensure that run commands are not defining `shell=True`

### DIFF
--- a/.github/workflows/bump_external_releases.py
+++ b/.github/workflows/bump_external_releases.py
@@ -4,11 +4,10 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import json
+import subprocess  # nosec: disable=B603
 import sys
 import traceback
 from pathlib import Path
-from subprocess import check_call
-from subprocess import PIPE
 from urllib.request import urlopen
 
 
@@ -18,7 +17,7 @@ if sys.version_info < (3, 6):
 
 def bump_release(github_project, tool_name):
     try:
-        with urlopen(f"https://api.github.com/repos/{github_project}/releases/latest") as request:
+        with urlopen(f"https://api.github.com/repos/{github_project}/releases/latest") as request:  # nosec: disable=B310
             latest_version = json.load(request)["name"]
     except:  # noqa: E722 (allow usage of bare 'except')
         traceback.print_exc()
@@ -39,7 +38,7 @@ def bump_release(github_project, tool_name):
 
     def call(*args):
         print(f"Executing: {args}")
-        check_call(args=args, stdout=PIPE)
+        subprocess.check_call(args=args, stdout=subprocess.PIPE)  # nosec: disable=B603
 
     call("pre-commit", "run", str(tool_name_version_path.absolute()))
     call("git", "add", str(tool_name_version_path.absolute()))

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,8 @@ repos:
   hooks:
   - id: mypy
     exclude: ^(\.github/workflows/bump_external_releases\.py)$
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.6.2
+  hooks:
+  - id: bandit
+    exclude: ^tests/.*\.py$

--- a/language_formatters_pre_commit_hooks/pre_conditions.py
+++ b/language_formatters_pre_commit_hooks/pre_conditions.py
@@ -16,7 +16,7 @@ if getattr(typing, "TYPE_CHECKING", False):
 
 def _is_command_success(*command_args):
     # type: (typing.Text) -> bool
-    exit_status, _ = run_command(" ".join(command_args))
+    exit_status, _ = run_command(*command_args)
     return exit_status == 0
 
 

--- a/language_formatters_pre_commit_hooks/pretty_format_golang.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_golang.py
@@ -17,7 +17,7 @@ def _get_eol_attribute():
     Retrieve eol attribute defined for golang files
     The method will return None in case of any error interacting with git
     """
-    status_code, output = run_command("git check-attr -z eol -- filename.go")
+    status_code, output = run_command("git", "check-attr", "-z", "eol", "--", "filename.go")
     if status_code != 0:
         return None
 
@@ -49,12 +49,10 @@ def pretty_format_golang(argv=None):
     parser.add_argument("filenames", nargs="*", help="Filenames to fix")
     args = parser.parse_args(argv)
 
-    status, output = run_command(
-        "gofmt{} -l {}".format(
-            " -w" if args.autofix else "",
-            " ".join(set(args.filenames)),
-        ),
-    )
+    cmd_args = ["gofmt", "-l"]
+    if args.autofix:
+        cmd_args.append("-w")
+    status, output = run_command(*(cmd_args + args.filenames))
 
     if status != 0:  # pragma: no cover
         print(output)

--- a/language_formatters_pre_commit_hooks/pretty_format_java.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_java.py
@@ -68,14 +68,14 @@ def pretty_format_java(argv=None):
         args.google_java_formatter_version,
     )
 
-    status, output = run_command(
-        "java -jar {} --set-exit-if-changed{} {} {}".format(
-            google_java_formatter_jar,
-            " --aosp" if args.aosp else "",
-            "--replace" if args.autofix else "--dry-run",
-            " ".join(set(args.filenames)),
-        ),
-    )
+    cmd_args = ["java", "-jar", google_java_formatter_jar, "--set-exit-if-changed"]
+    if args.aosp:  # pragma: no cover
+        cmd_args.append("--aosp")
+    if args.autofix:
+        cmd_args.append("--replace")
+    else:
+        cmd_args.append("--dry-run")
+    status, output = run_command(*(cmd_args + args.filenames))
 
     if output:
         print(

--- a/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
@@ -63,12 +63,7 @@ def pretty_format_kotlin(argv=None):
     # To workaround this limitation we do run ktlint in check mode only,
     # which provides the expected exit status and we run it again in format
     # mode if autofix flag is enabled
-    check_status, check_output = run_command(
-        "java -jar {} --verbose --relative -- {}".format(
-            ktlint_jar,
-            " ".join(set(args.filenames)),
-        ),
-    )
+    check_status, check_output = run_command("java", "-jar", ktlint_jar, "--verbose", "--relative", "--", *args.filenames)
 
     not_pretty_formatted_files = set()  # type: typing.Set[typing.Text]
     if check_status != 0:
@@ -76,12 +71,7 @@ def pretty_format_kotlin(argv=None):
 
         if args.autofix:
             print("Running ktlint format on {}".format(not_pretty_formatted_files))
-            run_command(
-                "java -jar {} --verbose --relative --format -- {}".format(
-                    ktlint_jar,
-                    " ".join(not_pretty_formatted_files),
-                ),
-            )
+            run_command("java", "-jar", ktlint_jar, "--verbose", "--relative", "--format", "--", *not_pretty_formatted_files)
 
     status = 0
     if not_pretty_formatted_files:

--- a/language_formatters_pre_commit_hooks/pretty_format_rust.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_rust.py
@@ -28,12 +28,7 @@ def pretty_format_rust(argv=None):
 
     rust_toolchain_version = getenv("RUST_TOOLCHAIN", "stable")
     # Check
-    status_code, output = run_command(
-        "cargo +{} fmt -- --check {}".format(
-            rust_toolchain_version,
-            " ".join(set(args.filenames)),
-        ),
-    )
+    status_code, output = run_command("cargo", "+{}".format(rust_toolchain_version), "fmt", "--", "--check", *args.filenames)
     not_well_formatted_files = sorted(line.split()[2] for line in output.splitlines() if line.startswith("Diff in "))
     if not_well_formatted_files:
         print(
@@ -43,12 +38,7 @@ def pretty_format_rust(argv=None):
             ),
         )
         if args.autofix:
-            run_command(
-                "cargo +{} fmt -- {}".format(
-                    rust_toolchain_version,
-                    " ".join(not_well_formatted_files),
-                ),
-            )
+            run_command("cargo", "+{}".format(rust_toolchain_version), "fmt", "--", *not_well_formatted_files)
 
     return 1 if status_code != 0 or not_well_formatted_files else 0
 

--- a/language_formatters_pre_commit_hooks/utils.py
+++ b/language_formatters_pre_commit_hooks/utils.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 import os
 import shutil
-import subprocess
+import subprocess  # nosec: disable=B603
 import sys
 import tempfile
 import typing
@@ -14,17 +14,16 @@ import requests
 from six.moves.urllib.parse import urlparse
 
 
-def run_command(command):
+def run_command(*command):
     # type: (typing.Text) -> typing.Tuple[int, typing.Text]
     print("[cwd={cwd}] Run command: {command}".format(command=command, cwd=os.getcwd()), file=sys.stderr)
     return_code, output = 1, ""
     try:
         return_code, output = (
             0,
-            subprocess.check_output(
+            subprocess.check_output(  # nosec: disable=B603
                 command,
                 stderr=subprocess.STDOUT,
-                shell=True,
             ).decode("utf-8"),
         )
     except subprocess.CalledProcessError as e:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -19,25 +19,13 @@ from language_formatters_pre_commit_hooks.utils import run_command
 @pytest.mark.parametrize(
     "command, expected_status, expected_output",
     [
-        ("echo 1", 0, "1{}".format(os.linesep)),
-        pytest.param(
-            "echo 1 | grep 0",
-            1,
-            "",
-            marks=pytest.mark.skipif(condition=sys.platform == "win32", reason="Windows does not have `grep`"),
-        ),
-        pytest.param(
-            "echo 1 | findstr 0",
-            1,
-            "",
-            marks=pytest.mark.skipif(condition=sys.platform != "win32", reason="Linux and MacOS does not have `findstr`"),
-        ),
-        ["true", 0, ""],
-        ["false", 1, ""],
+        (["echo", "1"], 0, "1{}".format(os.linesep)),
+        (["true"], 0, ""),
+        (["false"], 1, ""),
     ],
 )
 def test_run_command(command, expected_status, expected_output):
-    assert run_command(command) == (expected_status, expected_output)
+    assert run_command(*command) == (expected_status, expected_output)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR is based on top of #37 . Once the parent PR is merged I'll rebase this on master such to have a smaller diff.

This PR removes the usage of
```python
import subprocess
command = ...  # a string as you would write in on the shell
subprocess.check_output(command, shell=True)
```
and replaces it with
```python
import subprocess
command = [...]  # a list of strings (as for `exec` call)
subprocess.check_output(command)
```
the change enhance security as it removes the shell-injection vulnerability.

In order to further prevent such vulnerabilities to be added on the codebase I've added [bandit](https://github.com/PyCQA/bandit) (a security linter) in the pre-commit hooks.
