### PR TITLE
Add dockerization

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -16,7 +16,7 @@
   name: Google Java Formatter
   description: Runs Google Java Formatter over Java source files
   entry: pretty-format-java
-  language: python
+  language: docker
   types: [java]
   # this is needed because the hook downloads google-java-formatter and
   # we don't have yet a nice way of ensuring a single download over multiple runs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:18.04
+
+# Make sure dependencies are installed
+RUN apt-get update && apt-get install -y python3 python3-pip
+RUN apt-get install -y python3-setuptools
+RUN apt install -y default-jre
+RUN pip3 install setuptools --upgrade
+
+# Put the source files in the build container
+COPY . /src/
+
+# Set working directory to where we want to run install commands from
+WORKDIR /src
+
+# Install formattters to container
+RUN python3 /src/setup.py install
+
+# Configure environment variables into writeable directory
+RUN mkdir -p /src/cache/.python-eggs
+RUN chmod 777 /src/cache
+ENV PYTHON_EGG_CACHE=/src/cache/.python-eggs
+ENV PRE_COMMIT_HOME /src/cache
+
+ENTRYPOINT /bin/bash

--- a/language_formatters_pre_commit_hooks/utils.py
+++ b/language_formatters_pre_commit_hooks/utils.py
@@ -75,7 +75,7 @@ def download_url(url, file_name=None):
         tmp_file.flush()
         os.fsync(tmp_file.fileno())
 
-    os.rename(tmp_file_name, final_file)
+    shutil.copy(tmp_file_name, final_file)
 
     return final_file
 


### PR DESCRIPTION
While recently adding [Google's Java Style](https://google.github.io/styleguide/javaguide.html),  I ran into the issue that my existing project only supports Java 8, while the most current version of [google-java-format](https://github.com/google/google-java-format) requires Java 11. Using an older version of `google-java-format` isn't acceptable as the current [Intellij formatting tools](https://plugins.jetbrains.com/plugin/8527-google-java-format) for Google's Java Style do not produce output compatible with a Java 8 version of `google-java-format`.

My solution was to wrap this repo into a Docker container that has Java 11 installed, and isolated from my project that can only support Java 8. 

