### PR TITLE
Add FAQ to address #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,15 @@
+# Language Formatters Pre Commit Hooks
 
-<a href="https://github.com/macisamuele/language-formatters-pre-commit-hooks/actions" alt="Github Actions CI">
-    <img src="https://github.com/macisamuele/language-formatters-pre-commit-hooks/workflows/Build/badge.svg"/>
-</a>
-<a href="https://codecov.io/gh/macisamuele/language-formatters-pre-commit-hooks" alt="Coverage">
-    <img src="https://img.shields.io/codecov/c/github/macisamuele/language-formatters-pre-commit-hooks/master.svg"/>
-</a>
+[![Github Actions CI](https://github.com/macisamuele/language-formatters-pre-commit-hooks/workflows/Build/badge.svg)](https://github.com/macisamuele/language-formatters-pre-commit-hooks/actions)
+[![Coverage](https://img.shields.io/codecov/c/github/macisamuele/language-formatters-pre-commit-hooks/master.svg)](https://codecov.io/gh/macisamuele/language-formatters-pre-commit-hooks)
+[![PyPi version](https://img.shields.io/pypi/v/language-formatters-pre-commit-hooks.svg)](https://pypi.python.org/pypi/language-formatters-pre-commit-hooks/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/language-formatters-pre-commit-hooks.svg)](https://pypi.python.org/pypi/language-formatters-pre-commit-hooks/)
 
-<a href="https://pypi.python.org/pypi/language-formatters-pre-commit-hooks/" alt="PyPi version">
-    <img src="https://img.shields.io/pypi/v/language-formatters-pre-commit-hooks.svg"/>
-</a>
-
-<a href="https://pypi.python.org/pypi/language-formatters-pre-commit-hooks/" alt="Supported Python versions">
-    <img src="https://img.shields.io/pypi/pyversions/language-formatters-pre-commit-hooks.svg"/>
-</a>
-
-Language Formatters Pre Commit Hooks
-====================================
-
-About
------
+## About
 
 This package provides utilities for ensuring that your code is nicely formatted by using [`pre-commit`](https://pre-commit.com/) hooks
 
-List of pretty-format hooks
----------------------------
+## List of pretty-format hooks
 
 * `pretty-format-golang`
 * `pretty-format-ini`
@@ -33,11 +19,11 @@ List of pretty-format hooks
 * `pretty-format-toml`
 * `pretty-format-yaml`
 
-⚠: the list above could be out-of-sync respect the exposed pre-commit hooks.<br/>
+⚠: the list above could be out-of-sync respect the exposed pre-commit hooks.
+
 Please refer to [`.pre-commit-hooks.yaml`](.pre-commit-hooks.yaml) for a more updated list.
 
-Example Usage
--------------
+## Example Usage
 
 Add a similar snippet into your `.pre-commit-config.yaml` file
 
@@ -54,25 +40,83 @@ Add a similar snippet into your `.pre-commit-config.yaml` file
     args: [--autofix, --indent, '2']
 ```
 
-Development
-===========
+## Development
 
-This tool uses tox as main tool to build virtual environments.<br/>
+This tool uses tox as main tool to build virtual environments.
+
 To get started will be enough to run `make development`.
 
 If you have [`aactivator`](https://github.com/Yelp/aactivator) installed this step will happen automatically.
 
-Contributing
-------------
+### Contributing
 
 Contributions are _always_ welcome.
-1. Fork the project ( http://github.com/macisamuele/language-formatters-pre-commit-hooks/fork )
+
+1. Fork the project ( <http://github.com/macisamuele/language-formatters-pre-commit-hooks/fork> )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Add your modifications
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
 
-License
--------
+## FAQ
+
+### How to deal with multiple Java versions?
+
+This might be relavant for `pretty-format-java` and `pretty-format-kotlin` hooks.
+The hooks depends on having `java` on version 11 or greather installed on your machine.
+
+Still, as you're working with compiled-to-JVM languages it would be reasonable to assume that `java` would be installed on your system, but then it would not be reasonable thinking that you have the minimum required version insalled.
+
+To work-around such type of issue you have 2 main approaches available
+
+1. Have multiple JAVA versions installed on your system and ensure that while running the pre-commit hooks JRE 11+ is available on your `PATH` variable (ie. `PATH=${JRE_11_PATH}:${PATH} pre-commit run`).
+
+2. Work around the issue by using [`docker`](https://www.docker.com/).
+    ⚠: This approach has been tested (at the time of writing) on Linux and MacOS.
+
+    The appraoch should be prefered if you cannot install an additional JRE version on your system or if doing so is a big request (think to CI system within companies) but be aware that you ned to have `docker` installed on your system.
+
+    Add the following `Dockerfile` on your repository root (same directory where `.pre-commit-config.yaml` is stored)
+
+    ```Dockerfile
+    FROM python:3.7-alpine
+
+    # Install JRE-11 as we will run pre-commit hooks that depends an JAVA 11+
+    RUN apk add --no-cache openjdk11-jre
+
+    ENV PRE_COMMIT_HOME /pre-commit-docker-cache
+    ENV PRE_COMMIT_LANGUAGE_FORMATTERS_VERSION ${version of the library to install}
+
+    RUN set -x \
+        && pip install --no-cache-dir language-formatters-pre-commit-hooks==${PRE_COMMIT_LANGUAGE_FORMATTERS_VERSION} \
+
+        # Run pre-commit-hook to ensure that jars are downloaded and stored in the docker image
+        # Run the hooks that you're planning to run within docker.
+        # This reduces premission issues as well has makes all the run fast as the lazy-dependencies are pre-fetched
+        && pretty-format-java  \
+
+        # Update permissions as hooks will be run as your host-system user (your username) but the image is built as root
+        && chmod a+r ${PRE_COMMIT_HOME}/*
+    ```
+
+    and the following hook into your `.pre-commit-config.yaml` file
+
+    ```yaml
+    repos:
+    - repo: local
+      hooks:
+      - id: pretty-format-java-in-docker    # Usful to eventually SKIP pre-commit hooks
+        name: pretty-format-java-in-docker  # This is required, put something sensible
+        language: docker                    # It explians itself
+        entry: pretty-format-java           # Hook that you want to run in docker
+        args: [...]                         # Arguments that would would pass to the hook (as if it was local)
+        files: ^.*\.java$                   # File filter has to be added ;)
+    ```
+
+    By doing the following, the selected hook (`pretty-format-java` in the example) will be executed within the docker container.
+
+    Side note: We're not embedding the Dockerfile in the repository as this is more a workaround to support whom cannot of installing a more recent Java version on the library-user system and as such we are not planning to fully support this other than giving possible solutions (Java 11+ was released in September, 2018).
+
+## License
 
 `language-formatters-pre-commit-hooks` is licensed with [`Apache License version 2.0`](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you have [`aactivator`](https://github.com/Yelp/aactivator) installed this st
 
 Contributions are _always_ welcome.
 
-1. Fork the project ( <http://github.com/macisamuele/language-formatters-pre-commit-hooks/fork> )
+1. [Fork the project](http://github.com/macisamuele/language-formatters-pre-commit-hooks/fork)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Add your modifications
 4. Push to the branch (`git push origin my-new-feature`)
@@ -62,26 +62,26 @@ Contributions are _always_ welcome.
 
 ### How to deal with multiple Java versions?
 
-This might be relavant for `pretty-format-java` and `pretty-format-kotlin` hooks.
-The hooks depends on having `java` on version 11 or greather installed on your machine.
+This might be relevant for `pretty-format-java` and `pretty-format-kotlin` hooks.
+The hooks depends on having `java` on version **11** or greater installed on your machine.
 
-Still, as you're working with compiled-to-JVM languages it would be reasonable to assume that `java` would be installed on your system, but then it would not be reasonable thinking that you have the minimum required version insalled.
+As you're working with _compiled-to-JVM_ languages, we assume that you have `java` installed on your system. You might not have the minimum required version installed.
 
-To work-around such type of issue you have 2 main approaches available
+To work-around such scenario you have 2 approaches available:
 
-1. Have multiple JAVA versions installed on your system and ensure that while running the pre-commit hooks JRE 11+ is available on your `PATH` variable (ie. `PATH=${JRE_11_PATH}:${PATH} pre-commit run`).
+1. Have multiple `java` versions installed on your system and ensure that while running the pre-commit hooks JRE 11+ is available on your `PATH` variable (ie. `PATH=${JRE_11_PATH}:${PATH} pre-commit run`).
 
 2. Work around the issue by using [`docker`](https://www.docker.com/).
     ⚠: This approach has been tested (at the time of writing) on Linux and MacOS.
 
-    The appraoch should be prefered if you cannot install an additional JRE version on your system or if doing so is a big request (think to CI system within companies) but be aware that you ned to have `docker` installed on your system.
+    The latter approach should be preferred if you cannot install an additional JRE version on your system or if doing is unfeasible (e.g. on a CI system). Please note you need to have `docker` installed on your system.
 
     Add the following `Dockerfile` on your repository root (same directory where `.pre-commit-config.yaml` is stored)
 
     ```Dockerfile
     FROM python:3.7-alpine
 
-    # Install JRE-11 as we will run pre-commit hooks that depends an JAVA 11+
+    # Install JRE-11 as we will run pre-commit hooks that depends an Java 11+
     RUN apk add --no-cache openjdk11-jre
 
     ENV PRE_COMMIT_HOME /pre-commit-docker-cache
@@ -105,9 +105,9 @@ To work-around such type of issue you have 2 main approaches available
     repos:
     - repo: local
       hooks:
-      - id: pretty-format-java-in-docker    # Usful to eventually SKIP pre-commit hooks
+      - id: pretty-format-java-in-docker    # Useful to eventually SKIP pre-commit hooks
         name: pretty-format-java-in-docker  # This is required, put something sensible
-        language: docker                    # It explians itself
+        language: docker                    # Self explanatory
         entry: pretty-format-java           # Hook that you want to run in docker
         args: [...]                         # Arguments that would would pass to the hook (as if it was local)
         files: ^.*\.java$                   # File filter has to be added ;)


### PR DESCRIPTION
The goal of this PR is to provide indication, to library users, on how to workaround multiple-java versions and/or the impossibility of installing a newer java version on their systems.

Thanks a lot to @mack1070101 for raising the initial concern on #42 .

As mentioned on the updated README we're are not going to embed this in the repository.
This because:
 * it would require us to support docker to support whom cannot have Java 11 installed (which was released 2 years ago)
 * it would require us to make testing more complex (having a Dockerfile in the repo means that we need to test it as well)
 * it would require us to publish the docker image on the docker-hub (to make it appreciable)