### PR TITLE
preserve_ini_comments

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_ini.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_ini.py
@@ -8,6 +8,7 @@ import io
 import sys
 import typing
 
+from iniparse import INIConfig
 from six import PY3
 from six import StringIO
 from six import text_type
@@ -36,18 +37,17 @@ def pretty_format_ini(argv=None):
         with open(ini_file) as input_file:
             string_content = "".join(input_file.readlines())
 
-        config_parser = ConfigParser()
         try:
+            # INIConfig only supports strict mode for throwing errors
+            config_parser = ConfigParser()
             if PY3:  # pragma: no cover # py3+ only
                 config_parser.read_string(string_content)
             else:  # pragma: no cover # py27 only
                 config_parser.readfp(StringIO(str(string_content)))
-
-            pretty_content = StringIO()
-            config_parser.write(pretty_content)
+            config_parser = INIConfig(StringIO(str(string_content)), parse_exc=False)
 
             pretty_content_str = remove_trailing_whitespaces_and_set_new_line_ending(
-                pretty_content.getvalue(),
+                str(config_parser),
             )
 
             if string_content != pretty_content_str:

--- a/language_formatters_pre_commit_hooks/pretty_format_ini.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_ini.py
@@ -44,10 +44,10 @@ def pretty_format_ini(argv=None):
                 config_parser.read_string(string_content)
             else:  # pragma: no cover # py27 only
                 config_parser.readfp(StringIO(str(string_content)))
-            config_parser = INIConfig(StringIO(str(string_content)), parse_exc=False)
+            ini_config = INIConfig(StringIO(str(string_content)), parse_exc=False)
 
             pretty_content_str = remove_trailing_whitespaces_and_set_new_line_ending(
-                str(config_parser),
+                str(ini_config),
             )
 
             if string_content != pretty_content_str:

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ version = 1.6.1
 
 [options]
 install_requires =
+    iniparse
     requests
     ruamel.yaml
     six

--- a/test-data/pretty_format_ini/not-pretty-formatted.ini
+++ b/test-data/pretty_format_ini/not-pretty-formatted.ini
@@ -1,5 +1,5 @@
 [root]
-root_key = "root_key"
+root_key = "root_key" #FIRST KEY
 
       [[inner]]
       inner_key = "inner_key"

--- a/test-data/pretty_format_ini/pretty-formatted.ini
+++ b/test-data/pretty_format_ini/pretty-formatted.ini
@@ -1,5 +1,5 @@
 [root]
-root_key = "root_key"
+root_key = "root_key" #FIRST KEY
 
 	[root.inner]
 	inner_key = "inner_key"


### PR DESCRIPTION
Closes #26 

I ended up using INIParse since it's more compatible with the ConfigParser library than ConfigObj and more lightweight. Adds one tiny dependency.