### PR TITLE
Bump pre-commit & fully deprecate Python 2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,14 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pyversion: [3.6, 3.7]
+        pyversion: [3.6, 3.7, 3.8]
         os: [macos-latest, ubuntu-latest, windows-latest]
-        exclude:
-        # Excluding tests on windows-python2.7 as there are failures on installing
-        # ruamel.yaml and I'm not looking forward to add effort on improving the build
-        # Windows tests will still be executed for python3+ so I guess that it should be fine
-        - os: windows-latest
-          pyversion: 2.7
 
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/bump_external_releases.py
+++ b/.github/workflows/bump_external_releases.py
@@ -40,7 +40,7 @@ def bump_release(github_project, tool_name):
         print(f"Executing: {args}")
         subprocess.check_call(args=args, stdout=subprocess.PIPE)  # nosec: disable=B603
 
-    call("pre-commit", "run", str(tool_name_version_path.absolute()))
+    call("pre-commit", "run", "--file", str(tool_name_version_path.absolute()))
     call("git", "add", str(tool_name_version_path.absolute()))
     call("git", "commit", "-m", message)
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,11 @@ default_language_version:
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit
-  rev: v2.7.1
+  rev: v2.9.3
   hooks:
   - id: validate_manifest
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v3.4.0
   hooks:
   - id: check-added-large-files
   - id: check-docstring-first
@@ -27,7 +27,7 @@ repos:
     exclude: ^test-data/.*$
   - id: fix-encoding-pragma
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v2.3.5
+  rev: v2.3.6
   hooks:
   - id: reorder-python-imports
     args:
@@ -38,7 +38,7 @@ repos:
     - --add-import
     - from __future__ import unicode_literals
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v1.5.0
+  rev: v1.6.1
   hooks:
   - id: pretty-format-yaml
     exclude: ^test-data/.*$
@@ -50,16 +50,16 @@ repos:
   - id: black
     args: [--config, .black.toml]
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.3
+  rev: 3.8.4
   hooks:
   - id: flake8
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.782
+  rev: v0.790
   hooks:
   - id: mypy
     exclude: ^(\.github/workflows/bump_external_releases\.py)$
 - repo: https://github.com/PyCQA/bandit
-  rev: 1.6.2
+  rev: 1.7.0
   hooks:
   - id: bandit
     exclude: ^tests/.*\.py$

--- a/language_formatters_pre_commit_hooks/__init__.py
+++ b/language_formatters_pre_commit_hooks/__init__.py
@@ -11,8 +11,7 @@ import pkg_resources
 __version__ = pkg_resources.get_distribution("language_formatters_pre_commit_hooks").version
 
 
-def _get_default_version(tool_name):  # pragma: no cover
-    # type: (typing.Text) -> typing.Text
+def _get_default_version(tool_name: str) -> str:  # pragma: no cover
     """
     Read tool_name default version.
     The method is intended to be used only from language_formatters_pre_commit_hooks modules

--- a/language_formatters_pre_commit_hooks/pre_conditions.py
+++ b/language_formatters_pre_commit_hooks/pre_conditions.py
@@ -10,24 +10,20 @@ from os import getenv
 from language_formatters_pre_commit_hooks.utils import run_command
 
 
-if getattr(typing, "TYPE_CHECKING", False):
-    F = typing.TypeVar("F", bound=typing.Callable[..., int])
+F = typing.TypeVar("F", bound=typing.Callable[..., int])
 
 
-def _is_command_success(*command_args):
-    # type: (typing.Text) -> bool
+def _is_command_success(*command_args: str) -> bool:
     exit_status, _ = run_command(*command_args)
     return exit_status == 0
 
 
 class ToolNotInstalled(RuntimeError):
-    def __init__(self, tool_name, download_install_url):
-        # type: (typing.Text, typing.Text) -> None
+    def __init__(self, tool_name: str, download_install_url: str) -> None:
         self.tool_name = tool_name
         self.download_install_url = download_install_url
 
-    def __str__(self):
-        # type: () -> str
+    def __str__(self) -> str:
         return str(
             "{tool_name} is required to run this pre-commit hook.\n"
             "Make sure that you have it installed and available on your path.\n"
@@ -39,21 +35,17 @@ class ToolNotInstalled(RuntimeError):
 
 
 class _ToolRequired(object):
-    def __init__(self, tool_name, check_command, download_install_url):
-        # type: (typing.Text, typing.Callable[[], bool], typing.Text) -> None
+    def __init__(self, tool_name: str, check_command: typing.Callable[[], bool], download_install_url: str) -> None:
         self.tool_name = tool_name
         self.check_command = check_command
         self.download_install_url = download_install_url
 
-    def is_tool_installed(self):
-        # type: () -> bool
+    def is_tool_installed(self) -> bool:
         return self.check_command()
 
-    def __call__(self, f):
-        # type: (F) -> F
+    def __call__(self, f: F) -> F:
         @wraps(f)
-        def wrapper(*args, **kwargs):
-            # type: (typing.Any, typing.Any) -> int
+        def wrapper(*args: typing.Any, **kwargs: typing.Any) -> int:
             if not self.is_tool_installed():
                 raise ToolNotInstalled(
                     tool_name=self.tool_name,

--- a/language_formatters_pre_commit_hooks/pretty_format_golang.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_golang.py
@@ -11,8 +11,7 @@ from language_formatters_pre_commit_hooks.pre_conditions import golang_required
 from language_formatters_pre_commit_hooks.utils import run_command
 
 
-def _get_eol_attribute():
-    # type: () -> typing.Optional[typing.Text]
+def _get_eol_attribute() -> typing.Optional[str]:
     """
     Retrieve eol attribute defined for golang files
     The method will return None in case of any error interacting with git
@@ -36,8 +35,7 @@ def _get_eol_attribute():
 
 
 @golang_required
-def pretty_format_golang(argv=None):
-    # type: (typing.Optional[typing.List[typing.Text]]) -> int
+def pretty_format_golang(argv: typing.Optional[typing.List[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",

--- a/language_formatters_pre_commit_hooks/pretty_format_ini.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_ini.py
@@ -7,19 +7,15 @@ import argparse
 import io
 import sys
 import typing
+from configparser import ConfigParser
+from configparser import Error
 
 from iniparse import INIConfig
-from six import PY3
-from six import StringIO
-from six import text_type
-from six.moves.configparser import ConfigParser
-from six.moves.configparser import Error
 
 from language_formatters_pre_commit_hooks.utils import remove_trailing_whitespaces_and_set_new_line_ending
 
 
-def pretty_format_ini(argv=None):
-    # type: (typing.Optional[typing.List[typing.Text]]) -> int
+def pretty_format_ini(argv: typing.Optional[typing.List[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",
@@ -40,11 +36,9 @@ def pretty_format_ini(argv=None):
         try:
             # INIConfig only supports strict mode for throwing errors
             config_parser = ConfigParser()
-            if PY3:  # pragma: no cover # py3+ only
-                config_parser.read_string(string_content)
-            else:  # pragma: no cover # py27 only
-                config_parser.readfp(StringIO(str(string_content)))
-            ini_config = INIConfig(StringIO(str(string_content)), parse_exc=False)
+            config_parser.read_string(string_content)
+
+            ini_config = INIConfig(io.StringIO(str(string_content)), parse_exc=False)
 
             pretty_content_str = remove_trailing_whitespaces_and_set_new_line_ending(
                 str(ini_config),
@@ -56,7 +50,7 @@ def pretty_format_ini(argv=None):
                 if args.autofix:
                     print("Fixing file {}".format(ini_file))
                     with io.open(ini_file, "w", encoding="UTF-8") as output_file:
-                        output_file.write(text_type(pretty_content_str))
+                        output_file.write(str(pretty_content_str))
 
                 status = 1
         except Error:

--- a/language_formatters_pre_commit_hooks/pretty_format_java.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_java.py
@@ -13,10 +13,8 @@ from language_formatters_pre_commit_hooks.utils import download_url
 from language_formatters_pre_commit_hooks.utils import run_command
 
 
-def __download_google_java_formatter_jar(version):  # pragma: no cover
-    # type: (typing.Text) -> typing.Text
-    def get_url(_version):
-        # type: (typing.Text) -> typing.Text
+def __download_google_java_formatter_jar(version: str) -> str:  # pragma: no cover
+    def get_url(_version: str) -> str:
         # Links extracted from https://github.com/google/google-java-format/
         return (
             "https://github.com/google/google-java-format/releases/download/"
@@ -39,8 +37,7 @@ def __download_google_java_formatter_jar(version):  # pragma: no cover
 
 
 @java_required
-def pretty_format_java(argv=None):
-    # type: (typing.Optional[typing.List[typing.Text]]) -> int
+def pretty_format_java(argv: typing.Optional[typing.List[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",

--- a/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
@@ -13,10 +13,8 @@ from language_formatters_pre_commit_hooks.utils import download_url
 from language_formatters_pre_commit_hooks.utils import run_command
 
 
-def __download_kotlin_formatter_jar(version):  # pragma: no cover
-    # type: (typing.Text) -> typing.Text
-    def get_url(_version):
-        # type: (typing.Text) -> typing.Text
+def __download_kotlin_formatter_jar(version: str) -> str:  # pragma: no cover
+    def get_url(_version: str) -> str:
         # Links extracted from https://github.com/pinterest/ktlint/
         return "https://github.com/pinterest/ktlint/releases/download/{version}/ktlint".format(
             version=_version,
@@ -36,8 +34,7 @@ def __download_kotlin_formatter_jar(version):  # pragma: no cover
 
 
 @java_required
-def pretty_format_kotlin(argv=None):
-    # type: (typing.Optional[typing.List[typing.Text]]) -> int
+def pretty_format_kotlin(argv: typing.Optional[typing.List[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",
@@ -65,7 +62,7 @@ def pretty_format_kotlin(argv=None):
     # mode if autofix flag is enabled
     check_status, check_output = run_command("java", "-jar", ktlint_jar, "--verbose", "--relative", "--", *args.filenames)
 
-    not_pretty_formatted_files = set()  # type: typing.Set[typing.Text]
+    not_pretty_formatted_files: typing.Set[str] = set()
     if check_status != 0:
         not_pretty_formatted_files.update(line.split(":", 1)[0] for line in check_output.splitlines())
 

--- a/language_formatters_pre_commit_hooks/pretty_format_rust.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_rust.py
@@ -13,8 +13,7 @@ from language_formatters_pre_commit_hooks.utils import run_command
 
 
 @rust_required
-def pretty_format_rust(argv=None):
-    # type: (typing.Optional[typing.List[typing.Text]]) -> int
+def pretty_format_rust(argv: typing.Optional[typing.List[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",

--- a/language_formatters_pre_commit_hooks/pretty_format_toml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_toml.py
@@ -14,8 +14,7 @@ from tomlkit.exceptions import ParseError
 from language_formatters_pre_commit_hooks.utils import remove_trailing_whitespaces_and_set_new_line_ending
 
 
-def pretty_format_toml(argv=None):
-    # type: (typing.Optional[typing.List[typing.Text]]) -> int
+def pretty_format_toml(argv: typing.Optional[typing.List[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",

--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -12,13 +12,9 @@ from sys import maxsize
 
 from ruamel.yaml import YAML
 from ruamel.yaml.error import YAMLError
-from six import StringIO
-from six import text_type
 
 
-def _process_single_document(document, yaml):
-    # type: (typing.Text, YAML) -> typing.Text
-
+def _process_single_document(document: str, yaml: YAML) -> str:
     """Pretty format one YAML document.
 
     This is needed in order to prevent `ruamel.yaml` to interfere with documents that have primitive types on the document root.
@@ -32,7 +28,7 @@ def _process_single_document(document, yaml):
     """
     content = yaml.load(document)
     if isinstance(content, (list, dict)):
-        pretty_output = StringIO()
+        pretty_output = io.StringIO()
         yaml.dump(content, pretty_output)
         return pretty_output.getvalue()
     else:
@@ -40,8 +36,7 @@ def _process_single_document(document, yaml):
         return str(document)
 
 
-def pretty_format_yaml(argv=None):
-    # type: (typing.Optional[typing.List[typing.Text]]) -> int
+def pretty_format_yaml(argv: typing.Optional[typing.List[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--autofix",
@@ -109,7 +104,7 @@ def pretty_format_yaml(argv=None):
                 if args.autofix:
                     print("Fixing file {}".format(yaml_file))
                     with io.open(yaml_file, "w", encoding="UTF-8") as output_file:
-                        output_file.write(text_type(pretty_content))
+                        output_file.write(str(pretty_content))
 
                 status = 1
         except YAMLError:  # pragma: no cover

--- a/language_formatters_pre_commit_hooks/utils.py
+++ b/language_formatters_pre_commit_hooks/utils.py
@@ -9,13 +9,12 @@ import subprocess  # nosec: disable=B603
 import sys
 import tempfile
 import typing
+from urllib.parse import urlparse
 
 import requests
-from six.moves.urllib.parse import urlparse
 
 
-def run_command(*command):
-    # type: (typing.Text) -> typing.Tuple[int, typing.Text]
+def run_command(*command: str) -> typing.Tuple[int, str]:
     print("[cwd={cwd}] Run command: {command}".format(command=command, cwd=os.getcwd()), file=sys.stderr)
     return_code, output = 1, ""
     try:
@@ -32,8 +31,7 @@ def run_command(*command):
     return return_code, output
 
 
-def _base_directory():
-    # type: () -> typing.Text
+def _base_directory() -> str:
     # Extracted from pre-commit code:
     # https://github.com/pre-commit/pre-commit/blob/master/pre_commit/store.py
     return os.path.realpath(
@@ -45,8 +43,7 @@ def _base_directory():
     )
 
 
-def download_url(url, file_name=None):
-    # type: (typing.Text, typing.Optional[typing.Text]) -> typing.Text
+def download_url(url: str, file_name: typing.Optional[str] = None) -> str:
     base_directory = _base_directory()
 
     final_file = os.path.join(
@@ -80,8 +77,7 @@ def download_url(url, file_name=None):
     return final_file
 
 
-def remove_trailing_whitespaces_and_set_new_line_ending(string):
-    # type: (typing.Text) -> typing.Text
+def remove_trailing_whitespaces_and_set_new_line_ending(string: str) -> str:
     return "{content}\n".format(
         content="\n".join(line.rstrip() for line in string.splitlines()).rstrip(),
     )

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 ignore_missing_imports = True
-python_version = 2.7
+python_version = 3.6
 strict_optional = True
 warn_redundant_casts = True
 warn_unused_configs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,11 +7,10 @@ author_email = macisamuele@gmail.com
 classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 description = List of pre-commit hooks meant to format your source code.
@@ -28,7 +27,6 @@ install_requires =
     iniparse
     requests
     ruamel.yaml
-    six
     toml-sort
     tomlkit
 packages = find:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,15 +9,14 @@ from contextlib import contextmanager
 from posixpath import basename
 from shutil import copyfile
 
-if getattr(typing, "TYPE_CHECKING", False):
-    import py
+import py
 
-    F = typing.TypeVar("F", bound=typing.Callable)
+
+F = typing.TypeVar("F", bound=typing.Callable)
 
 
 @contextmanager
-def change_dir_context(directory):
-    # type: (typing.Text) -> typing.Generator[None, None, None]
+def change_dir_context(directory: str) -> typing.Generator[None, None, None]:
     working_directory = os.getcwd()
     try:
         os.chdir(directory)
@@ -27,27 +26,24 @@ def change_dir_context(directory):
 
 
 @contextmanager
-def undecorate_function(func):
-    # type: (F) -> typing.Generator[F, None, None]
+def undecorate_function(func: F) -> typing.Generator[F, None, None]:
     passed_function = func
     func = getattr(passed_function, "__wrapped__", passed_function)
     yield func
     func = passed_function
 
 
-def __read_file(path):
-    # type: (typing.Text) -> typing.Text
+def __read_file(path: str) -> str:
     with open(path) as f:
         return "".join(f.readlines())
 
 
 def run_autofix_test(
-    tmpdir,  # type: py.path.local
-    method,  # type: typing.Callable[[typing.List[typing.Text]], int]
-    not_pretty_formatted_path,  # type: typing.Text
-    formatted_path,  # type: typing.Text
-):
-    # type: (...) -> None
+    tmpdir: py.path.local,
+    method: typing.Callable[[typing.List[str]], int],
+    not_pretty_formatted_path: str,
+    formatted_path: str,
+) -> None:
     tmpdir.mkdir("src")
     not_pretty_formatted_tmp_path = tmpdir.join("src").join(basename(not_pretty_formatted_path)).strpath
 

--- a/tests/pre_conditions_test.py
+++ b/tests/pre_conditions_test.py
@@ -23,8 +23,7 @@ def success(request):
         yield request.param
 
 
-def test__ToolRequired(success):
-    # type: (bool) -> None
+def test__ToolRequired(success: bool) -> None:
     decorator = _ToolRequired(tool_name="test", check_command=lambda: success, download_install_url="url")
     assert decorator.is_tool_installed() == success
 

--- a/tests/pretty_format_ini_test.py
+++ b/tests/pretty_format_ini_test.py
@@ -7,7 +7,6 @@ import os
 import shutil
 
 import pytest
-import six
 
 from language_formatters_pre_commit_hooks.pretty_format_ini import pretty_format_ini
 
@@ -25,14 +24,6 @@ def change_dir():
 @pytest.mark.parametrize(
     ("filename", "expected_retval"),
     (
-        pytest.param(
-            "pretty-formatted.ini",
-            0,
-            marks=pytest.mark.xfail(
-                condition=not six.PY3,
-                reason="ConfigParser writing format has changed between Python2 and Python3, let's test it only once",
-            ),
-        ),
         ("not-pretty-formatted.ini", 1),
         ("not-valid-file.ini", 1),
     ),

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -6,11 +6,11 @@ from __future__ import unicode_literals
 import os
 import sys
 from os.path import basename
+from urllib.parse import urljoin
+from urllib.request import pathname2url
 
 import mock
 import pytest
-from six.moves.urllib.parse import urljoin
-from six.moves.urllib.request import pathname2url
 
 from language_formatters_pre_commit_hooks.utils import download_url
 from language_formatters_pre_commit_hooks.utils import run_command

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 # These should match the travis env list
-envlist = py{27,36,37,38},pre-commit
+envlist = py{36,37,38},pre-commit
 
 [gh-actions]
 python =
-    2.7: py27
     3.6: py36
     3.7: py37
     3.8: py38


### PR DESCRIPTION
Bump pre-commit & fully deprecate Python 2

Additionally typing comments have been moved into their annotation form as well as `six` dependency has been removed