### PR TITLE
Add py39 tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # These should match the travis env list
-envlist = py{36,37,38},pre-commit
+envlist = py{36,37,38,39},pre-commit
 
 [gh-actions]
 python =


### PR DESCRIPTION
I recently added testing for Python3.9 but I missed adding the py39 environment.
This lack essentially made the py39 tests being no-ops and as such giving a false illusion that tests are green (you can check [this](https://github.com/macisamuele/language-formatters-pre-commit-hooks/pull/63/checks?check_run_id=2705730952) to observe the lack of tests execution).

This PR fixes it