### PR TITLE
Update `run_autofix_test` to not inject absolute paths

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -45,14 +45,14 @@ def run_autofix_test(
     formatted_path: str,
 ) -> None:
     tmpdir.mkdir("src")
-    not_pretty_formatted_tmp_path = tmpdir.join("src").join(basename(not_pretty_formatted_path)).strpath
+    not_pretty_formatted_tmp_path = tmpdir.join("src").join(basename(not_pretty_formatted_path))
 
     copyfile(not_pretty_formatted_path, not_pretty_formatted_tmp_path)
     with change_dir_context(tmpdir.strpath):
-        assert method(["--autofix", not_pretty_formatted_tmp_path]) == 1
+        assert method(["--autofix", tmpdir.bestrelpath(not_pretty_formatted_tmp_path)]) == 1
 
     # file was formatted (shouldn't trigger linter again)
     with change_dir_context(tmpdir.strpath):
-        assert method(["--autofix", not_pretty_formatted_tmp_path]) == 0
+        assert method(["--autofix", tmpdir.bestrelpath(not_pretty_formatted_tmp_path)]) == 0
 
     assert __read_file(not_pretty_formatted_tmp_path) == __read_file(formatted_path)


### PR DESCRIPTION
This change is needed because KTLint, starting from version 0.41.0, dropped support for absolute paths (https://github.com/pinterest/ktlint/issues/1131)

While running pre-commit hooks the injected paths are paths relative to GIT_ROOT, so the presence of absolute paths is merely an artifact of testing.