### PR TITLE
Handle latest ktlint on windows

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -66,7 +66,7 @@ def pretty_format_yaml(argv: typing.Optional[typing.List[str]] = None) -> int:
     yaml.indent = args.indent
     yaml.preserve_quotes = args.preserve_quotes
     # Prevent ruamel.yaml to wrap yaml lines
-    yaml.width = maxsize
+    yaml.width = maxsize  # type: ignore  # mypy recognise yaml.width as None
 
     separator = "---\n"
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,17 +5,7 @@ strict_optional = True
 warn_redundant_casts = True
 warn_unused_configs = True
 
-[mypy-tests.*]
-check_untyped_defs = True
-disallow_incomplete_defs = True
-disallow_subclassing_any = True
-disallow_untyped_calls = False
-disallow_untyped_decorators = True
-no_implicit_optional = True
-warn_return_any = True
-warn_unused_ignores = True
-
-[mypy-language_formatters_pre_commit_hooks.*]
+[mypy-*]
 check_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_subclassing_any = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 .
 coverage
 mock
+mypy
 pre-commit
 pytest
 twine

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,11 @@ commands =
 
 [testenv:pre-commit]
 basepython = python3.9
+setenv =
+    SKIP=mypy
 commands =
     pre-commit run --all-files
+    mypy language_formatters_pre_commit_hooks tests
 
 [testenv:venv]
 basepython = python3.9


### PR DESCRIPTION
In the #66 we tried to address a new limitation/regression introduced by the latest ktlint version.
Once then the automated PR #67 was created we noticed that windows tests started to fail.

A more complete analysis is present in https://github.com/macisamuele/language-formatters-pre-commit-hooks/pull/67#issuecomment-851415271

The TL;DR; is
* ktlint does not accept paths like `src\file.kt` (which is the *correct* way of describing relative paths on Windows platform
* ktlint does  provide. paths like `src\file.kt` in the output reporting (which is odd)

This PR aims to work-the-issue-around by replacing `\` with `/` in the paths.

NOTE: This PR does also make some improvements on the typing of the codebase.

**WARNING**: ktlint is intentionally not bumped on this PR because I still want to make sure that tests are going to be green with 0.40.0.
Once this will be merged I'll be re-triggering tests of #67 so we can also ensure that they are going to be green (I did already run them locally on a Windows computer)