### PR TITLE
Change os.rename to shutil.move

### DIFF
--- a/language_formatters_pre_commit_hooks/utils.py
+++ b/language_formatters_pre_commit_hooks/utils.py
@@ -72,7 +72,7 @@ def download_url(url: str, file_name: typing.Optional[str] = None) -> str:
         tmp_file.flush()
         os.fsync(tmp_file.fileno())
 
-    os.rename(tmp_file_name, final_file)
+    shutil.move(tmp_file_name, final_file)
 
     return final_file
 

--- a/language_formatters_pre_commit_hooks/utils.py
+++ b/language_formatters_pre_commit_hooks/utils.py
@@ -66,13 +66,13 @@ def download_url(url: str, file_name: typing.Optional[str] = None) -> str:
     print("Downloading {url}".format(url=url), file=sys.stderr)
     r = requests.get(url, stream=True)
     r.raise_for_status()
-    with tempfile.NamedTemporaryFile(delete=False) as tmp_file:  # Not delete because we're renaming it
+    with tempfile.NamedTemporaryFile(dir=base_directory, delete=False) as tmp_file:  # Not delete because we're renaming it
         tmp_file_name = tmp_file.name
         shutil.copyfileobj(r.raw, tmp_file)
         tmp_file.flush()
         os.fsync(tmp_file.fileno())
 
-    shutil.move(tmp_file_name, final_file)
+    os.rename(tmp_file_name, final_file)
 
     return final_file
 


### PR DESCRIPTION
This method was failing if the tmp directory is on a different filesystem. shutil.move tests for this and copies/removes if rename is not possible.