### PR TITLE
Deprecate usage of third-party mock lib and install all needed typesheds

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ mypy
 pre-commit
 pytest
 twine
+types-pkg_resources
+types-requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 .
 coverage
-mock
 mypy
 pre-commit
 pytest

--- a/tests/pre_conditions_test.py
+++ b/tests/pre_conditions_test.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import mock
+from unittest.mock import patch
+
 import pytest
 
 from language_formatters_pre_commit_hooks.pre_conditions import _ToolRequired
@@ -15,7 +16,7 @@ from language_formatters_pre_commit_hooks.pre_conditions import ToolNotInstalled
 
 @pytest.fixture(params=[True, False])
 def success(request):
-    with mock.patch(
+    with patch(
         "language_formatters_pre_commit_hooks.pre_conditions.run_command",
         autospec=True,
         return_value=(0 if request.param else 1, ""),

--- a/tests/pretty_format_golang_test.py
+++ b/tests/pretty_format_golang_test.py
@@ -4,9 +4,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import shutil
+from unittest.mock import patch
 
 import pytest
-from mock import patch
 
 from language_formatters_pre_commit_hooks.pretty_format_golang import _get_eol_attribute
 from language_formatters_pre_commit_hooks.pretty_format_golang import pretty_format_golang

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -6,10 +6,10 @@ from __future__ import unicode_literals
 import os
 import sys
 from os.path import basename
+from unittest.mock import patch
 from urllib.parse import urljoin
 from urllib.request import pathname2url
 
-import mock
 import pytest
 
 from language_formatters_pre_commit_hooks.utils import download_url
@@ -35,14 +35,14 @@ def test_run_command(command, expected_status, expected_output):
         [urljoin("file://", pathname2url(__file__)), False],
     ],
 )
-@mock.patch("language_formatters_pre_commit_hooks.utils.shutil", autospec=True)
-@mock.patch("language_formatters_pre_commit_hooks.utils.requests", autospec=True)
+@patch("language_formatters_pre_commit_hooks.utils.shutil", autospec=True)
+@patch("language_formatters_pre_commit_hooks.utils.requests", autospec=True)
 def test_download_url(mock_requests, mock_shutil, tmpdir, url, does_file_already_exist):
     if does_file_already_exist:
         with open(os.path.join(tmpdir.strpath, basename(url)), "w") as f:
             f.write(str(""))
 
-    with mock.patch.dict(os.environ, {"PRE_COMMIT_HOME": tmpdir.strpath}):
+    with patch.dict(os.environ, {"PRE_COMMIT_HOME": tmpdir.strpath}):
         assert download_url(url) == os.path.join(tmpdir.strpath, basename(url))
 
     if does_file_already_exist:


### PR DESCRIPTION
This PR aims to remove usage of `mock` library (meant to be a backport of `unittest.mock` for Python versions before 3.3) and to fix the mypy reports identified on #69.

The mypy issues are essentially related to the fact that mypy does not find the typesheds for `pkg_resources` and `requests` library and as such it fails (because mypy is configured to be extra severe). By installing them we make sure that mypy is happy.