### PR TITLE
Add Java 16 support for java formatting

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_java.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_java.py
@@ -80,7 +80,23 @@ def pretty_format_java(argv: typing.Optional[typing.List[str]] = None) -> int:
         args.google_java_formatter_version,
     )
 
-    cmd_args = ["java", "-jar", google_java_formatter_jar, "--set-exit-if-changed"]
+    cmd_args = [
+        "java",
+        # export JDK internal classes for Java 16+
+        "--add-exports",
+        "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-exports",
+        "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+        "--add-exports",
+        "jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+        "--add-exports",
+        "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        "--add-exports",
+        "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+        "-jar",
+        google_java_formatter_jar,
+        "--set-exit-if-changed",
+    ]
     if args.aosp:  # pragma: no cover
         cmd_args.append("--aosp")
     if args.autofix:


### PR DESCRIPTION
Proposed fix for #72 .

For now, I did not add an option to disable the additional flags, as they are specific to the java binary and not the actual google formatter jar and are backwards compatible to Java 11.