### PR TITLE
Add mid jdk helpers

### DIFF
--- a/language_formatters_pre_commit_hooks/pre_conditions.py
+++ b/language_formatters_pre_commit_hooks/pre_conditions.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+import re
 import typing
 from functools import wraps
 from os import getenv
+
+from packaging.version import Version
 
 from language_formatters_pre_commit_hooks.utils import run_command
 
@@ -37,9 +40,9 @@ class _ToolRequired:
     def __init__(
         self,
         tool_name: str,
-        check_command: typing.Callable[[typing.Optional[typing.Mapping[str, str]]], bool],
+        check_command: typing.Callable[[typing.Optional[typing.Mapping[str, typing.Any]]], bool],
         download_install_url: str,
-        extras: typing.Optional[typing.Mapping[str, str]] = None,
+        extras: typing.Optional[typing.Mapping[str, typing.Any]] = None,
     ) -> None:
         self.tool_name = tool_name
         self.check_command = check_command
@@ -49,15 +52,17 @@ class _ToolRequired:
     def is_tool_installed(self) -> bool:
         return self.check_command(self.extras)
 
+    def assert_tool_installed(self) -> None:
+        if not self.is_tool_installed():
+            raise ToolNotInstalled(
+                tool_name=self.tool_name,
+                download_install_url=self.download_install_url,
+            )
+
     def __call__(self, f: F) -> F:
         @wraps(f)
         def wrapper(*args: typing.Any, **kwargs: typing.Any) -> int:
-            if not self.is_tool_installed():
-                raise ToolNotInstalled(
-                    tool_name=self.tool_name,
-                    download_install_url=self.download_install_url,
-                )
-
+            self.assert_tool_installed()
             return f(*args, **kwargs)
 
         return wrapper  # type: ignore
@@ -81,3 +86,68 @@ rust_required = _ToolRequired(
     check_command=(lambda _: _is_command_success("cargo", "+{}".format(getenv("RUST_TOOLCHAIN", "stable")), "fmt", "--", "--version")),
     download_install_url="https://github.com/rust-lang-nursery/rustfmt#quick-start",
 )
+
+
+class UnableToVerifyJDKVersion(RuntimeError):
+    def __str__(self) -> str:
+        return "Unable to verify the JDK version"  # pragma: no cover
+
+
+def get_jdk_version() -> Version:
+    """
+    Extract the version of the JDK accessible by the tool.
+
+    :raises UnableToVerifyJDKVersion: if it was not possible to gather the JDK version
+        This includes the case of `java` binary is not found in the path.
+    """
+    _, output = run_command("java", "-XshowSettings:properties", "-version")
+    try:
+        java_property_line = next(line for line in output.splitlines() if re.match(r"^\s+java.version\s+=\s+[^s]+$", line))
+        return Version(java_property_line.split()[-1])
+    except Exception as e:
+        raise UnableToVerifyJDKVersion() from e
+
+
+def assert_min_jdk_version(version: Version) -> None:
+    """
+    Ensure that the version of the accessible JDK is at least at the provided version.
+
+    :raises UnableToVerifyJDKVersion: if it was not possible to gather the JDK version
+        This includes the case of `java` binary is not found in the path.
+    :raises ToolNotInstalled: if `java` binary is found in the path but the JDK version does not
+        respect the min version requirement
+    """
+    _ToolRequired(
+        tool_name=f"JRE: min version {version}",
+        check_command=lambda extras: bool(extras and get_jdk_version() >= extras["min_sdk"]),
+        download_install_url="https://www.java.com/en/download/",
+        extras={"min_sdk": version},
+    ).assert_tool_installed()
+
+
+def assert_max_jdk_version(version: Version, *, inclusive: bool = False) -> None:
+    """
+    Ensure that the version of the accessible JDK is at most at the provided version.
+    The inclusive parameter allows us to include or exclude the specified version:
+    * if `inclusive=True` then `get_jdk_version() <= version` is evaluated
+    * if `inclusive=False` then `get_jdk_version() < version` is evaluated
+      NOTE: The missing `=` in the operation
+
+    :raises UnableToVerifyJDKVersion: if it was not possible to gather the JDK version
+        This includes the case of `java` binary is not found in the path.
+    :raises ToolNotInstalled: if `java` binary is found in the path but the JDK version does not
+        respect the max version requirement
+    """
+    if inclusive:
+        tool_name = f"JRE: version <= {version}"
+    else:
+        tool_name = f"JRE: version < {version}"
+
+    _ToolRequired(
+        tool_name=tool_name,
+        check_command=lambda extras: bool(
+            extras and (get_jdk_version() <= extras["max_sdk"] if inclusive else get_jdk_version() < extras["max_sdk"])
+        ),
+        download_install_url="https://www.java.com/en/download/",
+        extras={"max_sdk": version},
+    ).assert_tool_installed()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,5 @@ mypy
 pre-commit
 pytest
 twine
-types-pkg_resources
 types-requests
+types-setuptools

--- a/tests/pre_conditions_test.py
+++ b/tests/pre_conditions_test.py
@@ -1,15 +1,23 @@
 # -*- coding: utf-8 -*-
+import re
 import typing
+from textwrap import dedent
+from unittest.mock import Mock
 from unittest.mock import patch
 
 import pytest
+from packaging.version import Version
 
 from language_formatters_pre_commit_hooks.pre_conditions import _is_command_success
 from language_formatters_pre_commit_hooks.pre_conditions import _ToolRequired
+from language_formatters_pre_commit_hooks.pre_conditions import assert_max_jdk_version
+from language_formatters_pre_commit_hooks.pre_conditions import assert_min_jdk_version
+from language_formatters_pre_commit_hooks.pre_conditions import get_jdk_version
 from language_formatters_pre_commit_hooks.pre_conditions import golang_required
 from language_formatters_pre_commit_hooks.pre_conditions import java_required
 from language_formatters_pre_commit_hooks.pre_conditions import rust_required
 from language_formatters_pre_commit_hooks.pre_conditions import ToolNotInstalled
+from language_formatters_pre_commit_hooks.pre_conditions import UnableToVerifyJDKVersion
 
 
 @pytest.fixture(params=[True, False])
@@ -87,3 +95,114 @@ def test_tool_required(success, decorator, assert_content):
         assert raised_exception is None
     else:
         assert isinstance(raised_exception, ToolNotInstalled) and assert_content in str(raised_exception)
+
+
+@patch(
+    "language_formatters_pre_commit_hooks.pre_conditions.run_command",
+    autospec=True,
+    return_value=(1, ""),
+)
+def test_get_jdk_version_with_java_not_installed(_) -> None:
+    with pytest.raises(RuntimeError):
+        get_jdk_version()
+
+
+@pytest.mark.parametrize(
+    "command_output, expected_result",
+    (
+        ("", UnableToVerifyJDKVersion()),
+        (
+            dedent(
+                """
+                some output
+                that does not reflect the expected format
+                """
+            ),
+            UnableToVerifyJDKVersion(),
+        ),
+        (
+            dedent(
+                """
+
+                Property settings:
+                    file.encoding = UTF-8
+                    file.separator = /
+                    java.class.path =
+                    java.class.version = 60.0
+                    ...
+                    java.version = 16.0.2
+                    java.version.date = 2021-07-20
+                    ...
+
+                openjdk version "16.0.2" 2021-07-20
+                OpenJDK Runtime Environment Homebrew (build 16.0.2+0)
+                OpenJDK 64-Bit Server VM Homebrew (build 16.0.2+0, mixed mode, sharing)
+                """
+            ),
+            Version("16.0.2"),
+        ),
+    ),
+)
+@patch(
+    "language_formatters_pre_commit_hooks.pre_conditions.run_command",
+    autospec=True,
+)
+def test_get_jdk_version(mock_run_comand: Mock, command_output: str, expected_result: typing.Union[Exception, Version]) -> None:
+    mock_run_comand.return_value = (0, command_output)
+
+    if isinstance(expected_result, Exception):
+        with pytest.raises(type(expected_result)):
+            get_jdk_version()
+    elif isinstance(expected_result, Version):
+        assert get_jdk_version() == expected_result
+
+    else:
+        assert False, "We should never ever getting here"  # pragma: no cover
+
+
+@pytest.mark.parametrize("min_version_str, expected_error", (("11.0.0", False), ("15.0.0", False), ("16.0.0", True)))
+@patch(
+    "language_formatters_pre_commit_hooks.pre_conditions.get_jdk_version",
+    autospec=True,
+    return_value=Version("15.0.0"),
+)
+def test_assert_min_jdk_version(_: Mock, min_version_str: str, expected_error: bool) -> None:
+    version = Version(min_version_str)
+
+    try:
+        assert_min_jdk_version(version)
+    except ToolNotInstalled:
+        raised_exception = True
+    else:
+        raised_exception = False
+
+    assert raised_exception == expected_error
+
+
+@pytest.mark.parametrize(
+    "max_version_str, inclusive, expected_error",
+    (
+        ("11.0.0", True, True),
+        ("11.0.0", False, True),
+        ("15.0.0", True, False),
+        ("15.0.0", False, True),
+        ("16.0.0", True, False),
+        ("16.0.0", False, False),
+    ),
+)
+@patch(
+    "language_formatters_pre_commit_hooks.pre_conditions.get_jdk_version",
+    autospec=True,
+    return_value=Version("15.0.0"),
+)
+def test_assert_max_jdk_version(_: Mock, max_version_str: str, inclusive: bool, expected_error: bool) -> None:
+    version = Version(max_version_str)
+
+    try:
+        assert_max_jdk_version(version, inclusive=inclusive)
+    except ToolNotInstalled:
+        raised_exception = True
+    else:
+        raised_exception = False
+
+    assert raised_exception == expected_error

--- a/tests/pre_conditions_test.py
+++ b/tests/pre_conditions_test.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
+import typing
 from unittest.mock import patch
 
 import pytest
 
+from language_formatters_pre_commit_hooks.pre_conditions import _is_command_success
 from language_formatters_pre_commit_hooks.pre_conditions import _ToolRequired
 from language_formatters_pre_commit_hooks.pre_conditions import golang_required
 from language_formatters_pre_commit_hooks.pre_conditions import java_required
@@ -20,8 +22,30 @@ def success(request):
         yield request.param
 
 
+@pytest.mark.parametrize(
+    "matcher, expected_matcher_result",
+    (
+        (None, True),
+        (lambda output: output == "", True),
+        (lambda output: output != "", False),
+    ),
+)
+def test__is_command_success(
+    success: bool,
+    matcher: typing.Optional[typing.Callable[[str], bool]],
+    expected_matcher_result: bool,
+) -> None:
+
+    assert (success and expected_matcher_result) == _is_command_success(
+        "cmd",
+        "with",
+        "args",
+        output_should_match=matcher,
+    )
+
+
 def test__ToolRequired(success: bool) -> None:
-    decorator = _ToolRequired(tool_name="test", check_command=lambda: success, download_install_url="url")
+    decorator = _ToolRequired(tool_name="test", check_command=lambda _: success, download_install_url="url")
     assert decorator.is_tool_installed() == success
 
     def throw_exception():


### PR DESCRIPTION
The PR adds an helper method to allow determining the current Java JRE version available on the system as Google Java Formatter and KTLint are actually dependent on it.

In short:
* Google Java Formatter v1.10+ is compatible with JDK 16 but before that it is not really supported and currently the tool crashed with an odd Java stacktrace with is not really explicative of the issue
* KTLint seems needing some flags if running with new enough versions of the tool or on new enough Java versions

In order to unblock some changes that would allow us to actually release the new version of the library (#78) I'm proposing a separate PR such that @cortinico  can focus on the KTLint issue while I'll be focusing on the Google Java Formatter one.
