### PR TITLE
Use shutil.move for moving downloaded artifacts

### DIFF
--- a/language_formatters_pre_commit_hooks/utils.py
+++ b/language_formatters_pre_commit_hooks/utils.py
@@ -68,7 +68,7 @@ def download_url(url: str, file_name: typing.Optional[str] = None) -> str:
         tmp_file.flush()
         os.fsync(tmp_file.fileno())
 
-    os.rename(tmp_file_name, final_file)
+    shutil.move(tmp_file_name, final_file)
 
     return final_file
 


### PR DESCRIPTION
os.rename fails when the source and destination are in the different
filesystem. shutil.move takes care of that difference.

Fixes https://github.com/macisamuele/language-formatters-pre-commit-hooks/issues/82