### PR TITLE
Fix #86 OSError Invalid cross-device link error

### DIFF
--- a/language_formatters_pre_commit_hooks/utils.py
+++ b/language_formatters_pre_commit_hooks/utils.py
@@ -68,7 +68,7 @@ def download_url(url: str, file_name: typing.Optional[str] = None) -> str:
         tmp_file.flush()
         os.fsync(tmp_file.fileno())
 
-    os.rename(tmp_file_name, final_file)
+    shutil.move(tmp_file_name, final_file)
 
     return final_file
 


### PR DESCRIPTION
Fixes issue #86 where `download_url` fails if `/tmp` and the destination are not on the same filesystem. 