### PR TITLE
Make yaml file encoding explicit

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -67,7 +67,7 @@ def pretty_format_yaml(argv: typing.Optional[typing.List[str]] = None) -> int:
     separator = "---\n"
 
     for yaml_file in set(args.filenames):
-        with open(yaml_file) as input_file:
+        with open(yaml_file, encoding="utf8") as input_file:
             string_content = "".join(input_file.readlines())
 
         # Split multi-document file into individual documents


### PR DESCRIPTION
And more correct AFAIK. On Windows, with all current
python versions <= 3.10, the local cp* encoding is chosen.

Resulting in UnicodeDecodeError.