### PR TITLE
Update pretty-format-ini tool

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_ini.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_ini.py
@@ -3,10 +3,9 @@ import argparse
 import io
 import sys
 import typing
-from configparser import ConfigParser
-from configparser import Error
 
-from iniparse import INIConfig
+from configobj import ConfigObj
+from configobj import ParseError
 
 from language_formatters_pre_commit_hooks.utils import remove_trailing_whitespaces_and_set_new_line_ending
 
@@ -19,6 +18,13 @@ def pretty_format_ini(argv: typing.Optional[typing.List[str]] = None) -> int:
         dest="autofix",
         help="Automatically fixes encountered not-pretty-formatted files",
     )
+    parser.add_argument(
+        "--indent",
+        type=str,
+        default="    ",
+        dest="ini_indent",
+        help="INI Indentation characters (by default 4 spaces)",
+    )
 
     parser.add_argument("filenames", nargs="*", help="Filenames to fix")
     args = parser.parse_args(argv)
@@ -27,30 +33,28 @@ def pretty_format_ini(argv: typing.Optional[typing.List[str]] = None) -> int:
 
     for ini_file in set(args.filenames):
         with open(ini_file) as input_file:
-            string_content = "".join(input_file.readlines())
+            string_content_lines = input_file.read().splitlines()
 
         try:
-            # INIConfig only supports strict mode for throwing errors
-            config_parser = ConfigParser()
-            config_parser.read_string(string_content)
-
-            ini_config = INIConfig(io.StringIO(str(string_content)), parse_exc=False)
-
-            pretty_content_str = remove_trailing_whitespaces_and_set_new_line_ending(
-                str(ini_config),
+            config_object = ConfigObj(
+                infile=string_content_lines,
+                indent_type=args.ini_indent,
+                raise_errors=True,
             )
 
-            if string_content != pretty_content_str:
+            output_lines = [line.rstrip() for line in config_object.write()]
+
+            if string_content_lines != output_lines:
                 print("File {} is not pretty-formatted".format(ini_file))
 
                 if args.autofix:
                     print("Fixing file {}".format(ini_file))
                     with io.open(ini_file, "w", encoding="UTF-8") as output_file:
-                        output_file.write(str(pretty_content_str))
+                        output_file.write(remove_trailing_whitespaces_and_set_new_line_ending("\n".join(output_lines)))
 
                 status = 1
-        except Error:
-            print("Input File {} is not a valid INI file".format(ini_file))
+        except ParseError as e:
+            print("Input File {} is not a valid INI file: {}".format(ini_file, e))
             return 1
 
     return status

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ version = 2.3.0
 
 [options]
 install_requires =
-    iniparse
+    configobj
     packaging
     requests
     ruamel.yaml

--- a/test-data/pretty_format_ini/issue_99.ini
+++ b/test-data/pretty_format_ini/issue_99.ini
@@ -1,0 +1,9 @@
+[   flake8  ]
+
+
+
+max-line-length    =         88
+
+extend-ignore          =
+                                         E203
+

--- a/test-data/pretty_format_ini/not-pretty-formatted.ini
+++ b/test-data/pretty_format_ini/not-pretty-formatted.ini
@@ -4,5 +4,5 @@ root_key = "root_key" #FIRST KEY
       [[inner]]
       inner_key = "inner_key"
 
-[[inner]]
+[[inner2]]
 inner_key =     "inner_key"

--- a/test-data/pretty_format_ini/not-valid-file.ini
+++ b/test-data/pretty_format_ini/not-valid-file.ini
@@ -1,1 +1,1 @@
-: non valid toml
+: non valid ini file

--- a/test-data/pretty_format_ini/pretty-formatted.ini
+++ b/test-data/pretty_format_ini/pretty-formatted.ini
@@ -1,5 +1,5 @@
 [root]
-root_key = "root_key" #FIRST KEY
+    root_key = root_key    #FIRST KEY
 
-	[root.inner]
-	inner_key = "inner_key"
+[root.inner]
+    inner_key = inner_key

--- a/tests/pretty_format_ini_test.py
+++ b/tests/pretty_format_ini_test.py
@@ -20,8 +20,10 @@ def change_dir():
 @pytest.mark.parametrize(
     ("filename", "expected_retval"),
     (
+        ("issue_99.ini", 1),
         ("not-pretty-formatted.ini", 1),
         ("not-valid-file.ini", 1),
+        ("pretty-formatted.ini", 0),
     ),
 )
 def test_pretty_format_ini(filename, expected_retval):


### PR DESCRIPTION
This PR aims to address the ini parsing regression identified in #99.

The regression, as mentioned in the issue, was caused by the fact that we were hacking around to preserve comments in ini files.

In the original issue, #26, there was a possible recommendation on using `configobj` library as alternative.

After some analysis I came to realise that the suggested library is actually ensuring that the generated output is valid, proper indentation is enforced and comments are preserved.


Notable changes from this PR is that ini files like
```ini
key = value
```
would no longer be considered pretty because ini files need always to have sections, and if the section is missing then `root` is assumed.
With the new change, the default section would still be made explicit, hence
```ini
[root]
key = value
```
would be the prettified version of the previous content
---

Closes #99 and #100