### PR TITLE
Drop testing on Python 3.6 as it is at End of Life

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
 
         golang_version: [1.16.4]
         java_version: ['15', '16']
-        python_version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python_version: ['3.7', '3.8', '3.9', '3.10']
         rust_version: [stable]
 
     env:


### PR DESCRIPTION
^