### PR TITLE
Expose underlying tools error messages while tracking failure of pre-commit hook

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_ini.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_ini.py
@@ -39,7 +39,7 @@ def pretty_format_ini(argv: typing.Optional[typing.List[str]] = None) -> int:
                         output_file.write(pretty_content_str)
 
                 status = 1
-        except Exception as e:
+        except BaseException as e:
             print("Input File {} is not a valid INI file: {}".format(ini_file, e))
             return 1
 

--- a/language_formatters_pre_commit_hooks/pretty_format_toml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_toml.py
@@ -5,7 +5,6 @@ import sys
 import typing
 
 from toml_sort import TomlSort
-from tomlkit.exceptions import ParseError
 
 from language_formatters_pre_commit_hooks.utils import remove_trailing_whitespaces_and_set_new_line_ending
 
@@ -40,8 +39,8 @@ def pretty_format_toml(argv: typing.Optional[typing.List[str]] = None) -> int:
                         output_file.write(prettified_content)
 
                 status = 1
-        except ParseError:
-            print("Input File {} is not a valid TOML file".format(toml_file))
+        except BaseException as e:
+            print("Input File {} is not a valid TOML file: {}".format(toml_file, e))
             return 1
 
     return status

--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -7,7 +7,6 @@ import typing
 from sys import maxsize
 
 from ruamel.yaml import YAML
-from ruamel.yaml.error import YAMLError
 
 
 def _process_single_document(document: str, yaml: YAML) -> str:
@@ -113,11 +112,9 @@ def pretty_format_yaml(argv: typing.Optional[typing.List[str]] = None) -> int:
                         output_file.write(str(pretty_content))
 
                 status = 1
-        except YAMLError:  # pragma: no cover
+        except BaseException as e:  # pragma: no cover
             print(
-                "Input File {} is not a valid YAML file, consider using check-yaml".format(
-                    yaml_file,
-                ),
+                "Input File {} is not a valid YAML file, consider using check-yaml: {}".format(yaml_file, e),
             )
             return 1
 


### PR DESCRIPTION
The change would allow for possibly an easier debugging experience in case of failures.
Inspired by #110 suggestion