### PR TITLE
Temp fix for #133, by setting toml-sort dependency to version 0.20.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     packaging
     requests
     ruamel.yaml
-    toml-sort
+    toml-sort==0.20.2
     tomlkit
 packages = find:
 


### PR DESCRIPTION
This PR aims to fix issue #133, by setting the toml-sort dependency to version 0.20.2.
This (in my opinion) is the quickest way to fix (at least temporarily) issue #133.

I am aware there is another PR #134, which aims to fix issue #133, however failing tests prevent this change from being merged.
I am (also) under the impression that there may be some separate CI issues which prevent this from being merged (which may be fixed by #135). 

I have run the changes in #134 locally (i.e. separate from any CI issues which may be occurring) and unfortunately, it seems there would still be failing tests.

I have investigated what a more permanent fix would look like, however I need to perform further experimentation. I intend to continue investigating and experimenting with what these fixes these fixes would look like and submit a new PR (unless told otherwise).

Regardless of any future endeavour(s), I think this fix adds value. After CI issues are fixed by #135 this PR should allow, the pre-commit hook to be used without failing and fix failing tests. 