### PR TITLE
Ensure toml-sort to version 0.22+ and have explicit sort configuration

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_toml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_toml.py
@@ -5,6 +5,8 @@ import sys
 import typing
 
 from toml_sort import TomlSort
+from toml_sort.tomlsort import CommentConfiguration
+from toml_sort.tomlsort import FormattingConfiguration
 from toml_sort.tomlsort import SortConfiguration
 
 from language_formatters_pre_commit_hooks.utils import remove_trailing_whitespaces_and_set_new_line_ending
@@ -29,7 +31,22 @@ def pretty_format_toml(argv: typing.Optional[typing.List[str]] = None) -> int:
             string_content = "".join(input_file.readlines())
 
         try:
-            prettified_content = TomlSort(string_content, sort_config=SortConfiguration(tables=True)).sorted()
+            prettified_content = TomlSort(
+                input_toml=string_content,
+                comment_config=CommentConfiguration(
+                    header=True,
+                    footer=True,
+                    inline=True,
+                    block=True,
+                ),
+                sort_config=SortConfiguration(tables=True),
+                format_config=FormattingConfiguration(
+                    spaces_before_inline_comment=2,
+                    spaces_indent_inline_array=2,
+                    trailing_comma_inline_array=False,
+                ),
+            ).sorted()
+
             prettified_content = remove_trailing_whitespaces_and_set_new_line_ending(prettified_content)
             if string_content != prettified_content:
                 print("File {} is not pretty-formatted".format(toml_file))

--- a/language_formatters_pre_commit_hooks/pretty_format_toml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_toml.py
@@ -5,6 +5,7 @@ import sys
 import typing
 
 from toml_sort import TomlSort
+from toml_sort.tomlsort import SortConfiguration
 
 from language_formatters_pre_commit_hooks.utils import remove_trailing_whitespaces_and_set_new_line_ending
 
@@ -28,7 +29,7 @@ def pretty_format_toml(argv: typing.Optional[typing.List[str]] = None) -> int:
             string_content = "".join(input_file.readlines())
 
         try:
-            prettified_content = TomlSort(string_content).sorted()
+            prettified_content = TomlSort(string_content, sort_config=SortConfiguration(tables=True)).sorted()
             prettified_content = remove_trailing_whitespaces_and_set_new_line_ending(prettified_content)
             if string_content != prettified_content:
                 print("File {} is not pretty-formatted".format(toml_file))

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ install_requires =
     requests
     ruamel.yaml
     toml-sort>=0.22.0  # 0.22.0 introduces specific prettification configs (ie. SortConfiguration)
-    tomlkit
 packages = find:
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     packaging
     requests
     ruamel.yaml
-    toml-sort
+    toml-sort>=0.22.0  # 0.22.0 introduces specific prettification configs (ie. SortConfiguration)
     tomlkit
 packages = find:
 

--- a/test-data/pretty_format_toml/not-pretty-formatted.toml
+++ b/test-data/pretty_format_toml/not-pretty-formatted.toml
@@ -1,5 +1,5 @@
 [root]
-root_key = "root_key" #root
+root_key = "root_key"      #       root
 
       [[inner]]
       inner_key = "inner_key"

--- a/test-data/pretty_format_toml/not-pretty-formatted_fixed.toml
+++ b/test-data/pretty_format_toml/not-pretty-formatted_fixed.toml
@@ -5,4 +5,4 @@ inner_key = "inner_key"
 inner_key = "inner_key"
 
 [root]
-root_key = "root_key" #root
+root_key = "root_key"  # root


### PR DESCRIPTION
See, PR #136 for context *first*.

This PR builds on the PR #136, by updating to the latest toml-sort version (0.22.1), however the previous PR should be sufficient to prevent get the pre-commit hook working.