### PR TITLE
Update tox passenv definition

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,11 @@ python =
 
 [testenv]
 deps = -rrequirements-dev.txt
-passenv = CI HOME HOMEPATH PROGRAMDATA
+passenv =
+    CI
+    HOME
+    HOMEPATH
+    PROGRAMDATA
 setenv =
     GIT_AUTHOR_NAME = "test"
     GIT_COMMITTER_NAME = "test"


### PR DESCRIPTION
Latest version of tox fails to recognise enc variables in passenv if space separated. They should be comma separated or in new lines.
To ensure compatibility with previous tox versions I'm using the multiple lines approach (https://tox.wiki/en/latest/upgrading.html) 