### PR TITLE
Expand pretty-format-yaml to allow customisation of offset

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_yaml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_yaml.py
@@ -43,7 +43,13 @@ def pretty_format_yaml(argv: typing.Optional[typing.List[str]] = None) -> int:
         "--indent",
         type=int,
         default="2",
-        help="The number of indent spaces or a string to be used as delimiter for indentation level e.g. 4 or '\t' (Default: 2)",
+        help="The number of spaces to be used as delimiter for indentation level (Default: %(default)s)",
+    )
+    parser.add_argument(
+        "--offset",
+        type=int,
+        default="0",
+        help="The number of spaces to be used as offset for nested structures (Default: %(default)s)",
     )
     parser.add_argument(
         "--preserve-quotes",
@@ -67,8 +73,16 @@ def pretty_format_yaml(argv: typing.Optional[typing.List[str]] = None) -> int:
 
     status = 0
 
+    if args.indent < args.offset + 2:
+        print(
+            "Indent should be at least 2 more than offset. \n"
+            "Invalid output could be resulting otherwise. \n"
+            "indent={}, offset={}".format(args.indent, args.offset)
+        )
+        return 1
+
     yaml = YAML()
-    yaml.indent = args.indent
+    yaml.indent(mapping=args.indent, sequence=args.indent, offset=args.offset)
     yaml.preserve_quotes = args.preserve_quotes
     # Prevent ruamel.yaml to wrap yaml lines
     yaml.width = args.line_width  # type: ignore  # mypy recognise yaml.width as None

--- a/test-data/pretty_format_yaml/offset2_indent4_not-pretty-formatted.yaml
+++ b/test-data/pretty_format_yaml/offset2_indent4_not-pretty-formatted.yaml
@@ -1,0 +1,3 @@
+root:
+- key: 1
+- value: "string"

--- a/test-data/pretty_format_yaml/offset2_indent4_pretty-formatted.yaml
+++ b/test-data/pretty_format_yaml/offset2_indent4_pretty-formatted.yaml
@@ -1,0 +1,3 @@
+root:
+  - key: 1
+  - value: string

--- a/tests/pretty_format_yaml_test.py
+++ b/tests/pretty_format_yaml_test.py
@@ -37,6 +37,18 @@ def test_pretty_format_yaml(filename, expected_retval):
 
 
 @pytest.mark.parametrize(
+    ("filename", "args", "expected_retval"),
+    (
+        ("offset2_indent4_pretty-formatted.yaml", ["--indent=1", "--offset=3"], 1),
+        ("offset2_indent4_pretty-formatted.yaml", ["--indent=4", "--offset=2"], 0),
+        ("offset2_indent4_not-pretty-formatted.yaml", ["--indent=4", "--offset=2"], 1),
+    ),
+)
+def test_pretty_format_yaml_custom_cli_arguments(filename, args, expected_retval):
+    assert pretty_format_yaml([filename] + args) == expected_retval
+
+
+@pytest.mark.parametrize(
     ("no_pretty_file_name, fixed_file_name"),
     (
         ("not-pretty-formatted.yaml", "not-pretty-formatted_fixed.yaml"),


### PR DESCRIPTION
Fix: #132 

@hdadhich01's report essentially highlights the fact that the current pretty-format-yaml tool does not offer configurable offset for nested structures and considering that some YAML prettifiers embedded into IDEs do have a non zero offset it would cause some friction with respect to "format-on-save" and pre-commit checks.

This PR aims to expose offset configuration such that cases like #132 can be handled via pre-commit hook configuration.
In the specific case of the report, the "IDE preferred" formatting would be preserved if `--indent=4` and `--offset=2` arguments are provided