### PR TITLE
update ktlint to not log in autofix mode

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
@@ -94,7 +94,7 @@ def pretty_format_kotlin(argv: typing.Optional[typing.List[str]] = None) -> int:
                 "-jar",
                 ktlint_jar,
                 "--log-level",
-                "debug",
+                "none",
                 "--relative",
                 "--format",
                 "--",


### PR DESCRIPTION
Fixes: #176 

Reduce verbosity of ktlint logs to avoid:
* lengthy and noisy logs in case of failures
* slowdowns induced by debug logs