### PR TITLE
Fix error on Python 3.12 due to missing "pkg_ressource"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ version = 2.10.0
 
 [options]
 install_requires =
+    setuptools
     config_formatter
     packaging
     requests


### PR DESCRIPTION
Fix #181.

From my local tests, it seems to work fine after declaring `setuptools` as a required dependency. :+1: 