### PR TITLE
Fix `run_command` to properly handle EOL on Windowd

### DIFF
--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -14,7 +14,7 @@ from language_formatters_pre_commit_hooks.utils import run_command
 @pytest.mark.parametrize(
     "command, expected_status, expected_output, expected_stderr",
     [
-        (["echo", "1"], 0, "1{}".format(os.linesep), ""),
+        (["echo", "1"], 0, "1\n", ""),
         (["true"], 0, "", ""),
         (["false"], 1, "", ""),
     ],


### PR DESCRIPTION
Even on windows echo returns `\n`, we need to update `run_command` tests to be aware of that.