### PR TITLE
Update mypy.ini to support python 3.7 syntax

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 ignore_missing_imports = True
-python_version = 3.6
+python_version = 3.7
 strict_optional = True
 warn_redundant_casts = True
 warn_unused_configs = True


### PR DESCRIPTION
Fix broken build as prevent mypy 1.6 have dropped support for python 3.6.

From the changelog
> Running mypy with --python-version 3.6, for example, is no longer supported. Python 3.6 hasn’t been properly supported by mypy for some time now, and this makes it explicit. This was contributed by Nikita Sobolev (PR [15668](https://github.com/python/mypy/pull/15668)).