### PR TITLE
Automatic ktfmt bump version

### DIFF
--- a/.github/workflows/bump_external_releases.py
+++ b/.github/workflows/bump_external_releases.py
@@ -47,6 +47,13 @@ def bump_release(github_project, tool_name):
     return True
 
 
+def bump_ktfmt():
+    return bump_release(
+        github_project="facebook/ktfmt",
+        tool_name="ktfmt",
+    )
+
+
 def bump_ktlint():
     return bump_release(
         github_project="pinterest/ktlint",
@@ -63,7 +70,7 @@ def bump_google_java_formatter():
 
 if __name__ == "__main__":
     something_is_bumped = False
-    for bumper in (bump_ktlint, bump_google_java_formatter):
+    for bumper in (bump_ktfmt, bump_ktlint, bump_google_java_formatter):
         something_is_bumped |= bumper()
 
     if not something_is_bumped:


### PR DESCRIPTION
The automatic release bumper is based on a very simple heuristic , if the version is tagged on the github project then the version is released.
Still, automated PRs will go through testing, and tests ensure that the default version is fetchable from the available release.
