### PR TITLE
Always use UTF-8 for TOML files

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_toml.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_toml.py
@@ -44,7 +44,7 @@ def pretty_format_toml(argv: typing.Optional[typing.List[str]] = None) -> int:
     status = 0
 
     for toml_file in set(args.filenames):
-        with open(toml_file) as input_file:
+        with open(toml_file, encoding="UTF-8") as input_file:
             string_content = "".join(input_file.readlines())
 
         try:


### PR DESCRIPTION
According to the TOML spec, [“A TOML file must be a valid UTF-8 encoded Unicode document”][1]. Before this commit, pretty-format-toml didn’t specify an encoding when opening TOML files. As a result, the character encoding used to decode TOML files [depended on the user’s][2] [system configuration][3]. This commit makes sure that TOML files are always decoded using UTF-8, regardless of how the user’s system is configured.

[1]: <https://toml.io/en/v1.0.0#spec>
[2]: <https://docs.python.org/3/library/functions.html#open>
[3]: <https://docs.python.org/3/library/locale.html#locale.getencoding>
