### PR TITLE
Use importlib to retrieve library version

### DIFF
--- a/language_formatters_pre_commit_hooks/__init__.py
+++ b/language_formatters_pre_commit_hooks/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import pkg_resources
+from importlib import metadata
 
 
-__version__ = pkg_resources.get_distribution("language_formatters_pre_commit_hooks").version
+__version__ = metadata.version("language_formatters_pre_commit_hooks")
 
 
 def _get_default_version(tool_name: str) -> str:  # pragma: no cover
@@ -10,13 +10,12 @@ def _get_default_version(tool_name: str) -> str:  # pragma: no cover
     Read tool_name default version.
     The method is intended to be used only from language_formatters_pre_commit_hooks modules
     """
+    version_file = "{tool_name}.version".format(tool_name=tool_name)
     try:
-        with open(
-            pkg_resources.resource_filename(
-                "language_formatters_pre_commit_hooks",
-                "{tool_name}.version".format(tool_name=tool_name),
-            )
-        ) as f:
-            return f.readline().split()[0]
+        for file in metadata.files("language_formatters_pre_commit_hooks") or ():
+            if file.name == version_file:
+                return file.read_text().strip()
+
+        raise RuntimeError("Default version for {tool_name} is not found".format(tool_name=tool_name))
     except:  # noqa: E722 (allow usage of bare 'except')  # pragma: no cover
         raise RuntimeError("No default version found for {tool_name}".format(tool_name=tool_name))

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,10 +8,9 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 description = List of pre-commit hooks meant to format your source code.
@@ -25,12 +24,14 @@ version = 2.13.0
 
 [options]
 install_requires =
-    setuptools
     config_formatter
+    importlib-metadata; python_version<"3.10"
     packaging
     requests
     ruamel.yaml
+    setuptools
     toml-sort>=0.22.0  # 0.22.0 introduces specific prettification configs (ie. SortConfiguration)
+
 packages = find:
 
 [options.packages.find]


### PR DESCRIPTION
This is meant to replace the deprecated `pkg_resources.get_distribution` APIs.

https://setuptools.pypa.io/en/latest/pkg_resources.html