### PR TITLE
Update ktfmt URL for 0.55+

### DIFF
--- a/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
@@ -32,9 +32,17 @@ def _download_ktlint_formatter_jar(version: str) -> str:  # pragma: no cover
 
 
 def _download_ktfmt_formatter_jar(version: str) -> str:  # pragma: no cover
-    url = "https://repo1.maven.org/maven2/com/facebook/ktfmt/{version}/ktfmt-{version}-jar-with-dependencies.jar".format(
-        version=version,
-    )
+    major, minor = map(int, version.split('.'))
+    # In version 0.55, ktfmt change the naming of the far jar from `-jar-with-dependencies.jar` to `-with-dependencies.jar`.
+    if (major, minor) <= (0, 54):
+        url = "https://repo1.maven.org/maven2/com/facebook/ktfmt/{version}/ktfmt-{version}-jar-with-dependencies.jar".format(
+            version=version,
+        )
+    else:
+        url = "https://repo1.maven.org/maven2/com/facebook/ktfmt/{version}/ktfmt-{version}-with-dependencies.jar".format(
+            version=version,
+        )
+
     try:
         return download_url(url)
     except:  # noqa: E722 (allow usage of bare 'except')

--- a/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
@@ -32,7 +32,7 @@ def _download_ktlint_formatter_jar(version: str) -> str:  # pragma: no cover
 
 
 def _download_ktfmt_formatter_jar(version: str) -> str:  # pragma: no cover
-    major, minor = map(int, version.split('.'))
+    major, minor = map(int, version.split("."))
     # In version 0.55, ktfmt change the naming of the far jar from `-jar-with-dependencies.jar` to `-with-dependencies.jar`.
     if (major, minor) <= (0, 54):
         url = "https://repo1.maven.org/maven2/com/facebook/ktfmt/{version}/ktfmt-{version}-jar-with-dependencies.jar".format(

--- a/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
+++ b/language_formatters_pre_commit_hooks/pretty_format_kotlin.py
@@ -4,6 +4,8 @@ import json
 import sys
 import typing
 
+from packaging.version import Version
+
 from language_formatters_pre_commit_hooks import _get_default_version
 from language_formatters_pre_commit_hooks.pre_conditions import java_required
 from language_formatters_pre_commit_hooks.utils import does_checksum_match
@@ -34,7 +36,7 @@ def _download_ktlint_formatter_jar(version: str) -> str:  # pragma: no cover
 def _download_ktfmt_formatter_jar(version: str) -> str:  # pragma: no cover
     major, minor = map(int, version.split("."))
     # In version 0.55, ktfmt change the naming of the far jar from `-jar-with-dependencies.jar` to `-with-dependencies.jar`.
-    if (major, minor) <= (0, 54):
+    if Version(version) < Version("0.55"):
         url = "https://repo1.maven.org/maven2/com/facebook/ktfmt/{version}/ktfmt-{version}-jar-with-dependencies.jar".format(
             version=version,
         )


### PR DESCRIPTION
We updated the ktfmt URL for 0.55+ so this updates the logic to handle it.

See https://repo1.maven.org/maven2/com/facebook/ktfmt/0.55/